### PR TITLE
Queue up requests by component id

### DIFF
--- a/.dj-config.toml
+++ b/.dj-config.toml
@@ -18,7 +18,7 @@ long_running = true
 
 [[commands]]
 name = "t"
-execute = "poetry run pytest tests && npm run-script test"
+execute = "poetry run pytest -m 'not slow' && poetry run pytest -m 'slow' && npm run-script test"
 
 [[commands]]
 name = "is"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,5 +45,8 @@ jobs:
       - name: isort check
         run: poetry run isort --settings pyproject.toml --check .
 
-      - name: Test with pytest
-        run: poetry run pytest tests
+      - name: Run tests
+        run: poetry run pytest -m "not slow"
+
+      - name: Run slow tests
+        run: poetry run pytest -m "slow"

--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ celerybeat-schedule
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 
+import pytest
+
 
 def pytest_configure():
     templates = [
@@ -14,10 +16,51 @@ def pytest_configure():
         "example.coffee",
     ]
 
+    unicorn_settings = {
+        "SERIAL": {"ENABLED": True, "TIMEOUT": 5},
+        "CACHE_ALIAS": "default",
+    }
+
+    caches = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "unique-snowflake",
+        }
+    }
+
     settings.configure(
         TEMPLATES=templates,
         ROOT_URLCONF="django_unicorn.urls",
         DATABASES=databases,
         INSTALLED_APPS=installed_apps,
         UNIT_TEST=True,
+        UNICORN=unicorn_settings,
+        CACHES=caches,
     )
+
+
+@pytest.fixture(autouse=True)
+def reset_unicorn_settings(settings):
+    """
+    This takes the original `UNICORN` settings before the test is run, runs the test, and then resets them afterwards.
+    This is required because mutating nested dictionaries does not reset them as expected by `pytest-django`.
+    More details in https://github.com/pytest-dev/pytest-django/issues/601#issuecomment-440676001.
+    """
+
+    # Get original settings
+    cache_settings = {**settings.CACHES}
+    unicorn_settings = {**settings.UNICORN}
+    django_unicorn_settings = {}
+
+    if hasattr(settings, "DJANGO_UNICORN"):
+        django_unicorn_settings = {**settings.DJANGO_UNICORN}
+
+    # Run test
+    yield
+
+    # Re-set original settings
+    settings.CACHES = cache_settings
+    settings.UNICORN = unicorn_settings
+
+    if django_unicorn_settings:
+        settings.DJANGO_UNICORN = django_unicorn_settings

--- a/django_unicorn/components.py
+++ b/django_unicorn/components.py
@@ -683,7 +683,6 @@ class UnicornView(TemplateView):
         component_name: str,
         component_key: str = "",
         parent: "UnicornView" = None,
-        use_cache=True,
         request: HttpRequest = None,
         kwargs: Dict[str, Any] = {},
     ) -> "UnicornView":
@@ -697,7 +696,6 @@ class UnicornView(TemplateView):
             param component_key: Key of the component to allow multiple components of the same name
                 to be differentiated. Optional.
             param parent: The parent component of the current component.
-            param use_cache: Get component from cache or force construction of component. Defaults to `True`.
             param kwargs: Keyword arguments for the component passed in from the template. Defaults to `{}`.
         
         Returns:
@@ -750,21 +748,20 @@ class UnicornView(TemplateView):
 
             return component
 
-        if use_cache:
-            if component_id in views_cache:
-                component_class = views_cache[component_id]
-                component = _construct_component(
-                    component_class=component_class,
-                    component_id=component_id,
-                    component_name=component_name,
-                    component_key=component_key,
-                    parent=parent,
-                    request=request,
-                    **kwargs,
-                )
-                logger.debug(f"Retrieve {component_id} from views cache")
+        if component_id in views_cache:
+            component_class = views_cache[component_id]
+            component = _construct_component(
+                component_class=component_class,
+                component_id=component_id,
+                component_name=component_name,
+                component_key=component_key,
+                parent=parent,
+                request=request,
+                **kwargs,
+            )
+            logger.debug(f"Retrieve {component_id} from views cache")
 
-                return component
+            return component
 
         locations = []
 

--- a/django_unicorn/message.py
+++ b/django_unicorn/message.py
@@ -34,8 +34,10 @@ class ComponentRequest:
         self.id = self.body.get("id")
         assert self.id, "Missing component id"
 
-        self.key = self.body.get("key", "")
         self.epoch = self.body.get("epoch", "")
+        assert self.epoch, "Missing epoch"
+
+        self.key = self.body.get("key", "")
 
         self.validate_checksum()
 

--- a/django_unicorn/message.py
+++ b/django_unicorn/message.py
@@ -32,10 +32,14 @@ class ComponentRequest:
         assert self.id, "Missing component id"
 
         self.key = self.body.get("key", "")
+        self.epoch = self.body.get("epoch", "")
 
         self.validate_checksum()
 
         self.action_queue = self.body.get("actionQueue", [])
+
+    def __repr__(self):
+        return f"ComponentRequest(id='{self.id}' key='{self.key}' epoch={self.epoch} data={self.data} action_queue={self.action_queue})"
 
     def validate_checksum(self):
         """

--- a/django_unicorn/message.py
+++ b/django_unicorn/message.py
@@ -16,7 +16,7 @@ class ComponentRequest:
     Parses, validates, and stores all of the data from the message request.
     """
 
-    def __init__(self, request):
+    def __init__(self, request, component_name):
         self.body = {}
 
         try:
@@ -24,6 +24,9 @@ class ComponentRequest:
             assert self.body, "Invalid JSON body"
         except JSONDecodeError as e:
             raise UnicornViewError("Body could not be parsed") from e
+
+        self.name = component_name
+        assert self.name, "Missing component name"
 
         self.data = self.body.get("data")
         assert self.data is not None, "Missing data"  # data could theoretically be {}
@@ -39,7 +42,7 @@ class ComponentRequest:
         self.action_queue = self.body.get("actionQueue", [])
 
     def __repr__(self):
-        return f"ComponentRequest(id='{self.id}' key='{self.key}' epoch={self.epoch} data={self.data} action_queue={self.action_queue})"
+        return f"ComponentRequest(name='{self.name}' id='{self.id}' key='{self.key}' epoch={self.epoch} data={self.data} action_queue={self.action_queue})"
 
     def validate_checksum(self):
         """

--- a/django_unicorn/settings.py
+++ b/django_unicorn/settings.py
@@ -1,19 +1,55 @@
 from django.conf import settings
 
 
-SETTINGS_KEY = "DJANGO_UNICORN"
+SETTINGS_KEY = "UNICORN"
+LEGACY_SETTINGS_KEY = f"DJANGO_{SETTINGS_KEY}"
 
 
 def get_settings():
-    django_unicorn_settings = {}
+    unicorn_settings = {}
 
-    if hasattr(settings, SETTINGS_KEY):
-        django_unicorn_settings = getattr(settings, SETTINGS_KEY)
+    if hasattr(settings, LEGACY_SETTINGS_KEY):
+        # TODO: Log deprecation message here
+        unicorn_settings = getattr(settings, LEGACY_SETTINGS_KEY)
+    elif hasattr(settings, SETTINGS_KEY):
+        unicorn_settings = getattr(settings, SETTINGS_KEY)
 
-    return django_unicorn_settings
+    return unicorn_settings
 
 
 def get_setting(key, default=None):
-    django_unicorn_settings = get_settings()
+    unicorn_settings = get_settings()
 
-    return django_unicorn_settings.get(key, default)
+    return unicorn_settings.get(key, default)
+
+
+def get_serial_settings():
+    return get_setting("SERIAL", {})
+
+
+def get_cache_alias():
+    return get_setting("CACHE_ALIAS", "default")
+
+
+def get_serial_enabled():
+    """
+    Default serial enabled is `False`.
+    """
+    enabled = get_serial_settings().get("ENABLED", False)
+
+    if enabled and settings.CACHES:
+        cache_alias = get_cache_alias()
+        cache_settings = settings.CACHES.get(cache_alias, {})
+        cache_backend = cache_settings.get("BACKEND")
+
+        if cache_backend == "django.core.cache.backends.dummy.DummyCache":
+            return False
+
+    return enabled
+
+
+def get_serial_timeout():
+    """
+    Default serial timeout is 60 seconds.
+    """
+    return get_serial_settings().get("TIMEOUT", 60)

--- a/django_unicorn/static/js/component.js
+++ b/django_unicorn/static/js/component.js
@@ -246,8 +246,7 @@ export class Component {
   handlePollError(err) {
     if (err) {
       console.error(err);
-    }
-    if (this.poll.timer) {
+    } else if (this.poll.timer) {
       clearInterval(this.poll.timer);
     }
   }

--- a/django_unicorn/static/js/messageSender.js
+++ b/django_unicorn/static/js/messageSender.js
@@ -30,6 +30,7 @@ export function send(component, callback) {
     data: component.data,
     checksum: component.checksum,
     actionQueue: component.currentActionQueue,
+    epoch: Date.now(),
   };
 
   const headers = {

--- a/django_unicorn/static/js/messageSender.js
+++ b/django_unicorn/static/js/messageSender.js
@@ -58,6 +58,10 @@ export function send(component, callback) {
         return;
       }
 
+      if (responseJson.queued && responseJson.queued === true) {
+        return;
+      }
+
       if (responseJson.error) {
         if (responseJson.error === "Checksum does not match") {
           // Reset the models if the checksum doesn't match

--- a/django_unicorn/views.py
+++ b/django_unicorn/views.py
@@ -521,7 +521,6 @@ def _handle_component_request(
     cache = caches[get_cache_alias()]
 
     # Add the current request `ComponentRequest` to the cache
-    # TODO: Add component name to `ComponentRequest` (grab it off of the request path?)
     component_cache_key = f"{component_request.name}:{component_request.id}"
     component_requests = cache.get(component_cache_key) or []
     component_requests.append(component_request)

--- a/django_unicorn/views.py
+++ b/django_unicorn/views.py
@@ -328,7 +328,6 @@ def _process_component_request(
                     component = UnicornView.create(
                         component_id=component_request.id,
                         component_name=component_request.name,
-                        use_cache=True,
                         request=request,
                     )
 
@@ -348,7 +347,6 @@ def _process_component_request(
                     component = UnicornView.create(
                         component_id=component_request.id,
                         component_name=component_request.name,
-                        use_cache=False,  # TODO: this probably doesn't matter for this now
                         request=request,
                     )
 

--- a/example/project/settings.py
+++ b/example/project/settings.py
@@ -53,6 +53,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "project.wsgi.application"
 
+
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
@@ -88,6 +89,9 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
+
+
+UNICORN = {"SERIAL": {"ENABLED": True, "TIMEOUT": 5,}, "CACHE_ALIAS": "default"}
 
 
 LOGGING = {

--- a/example/project/settings.py
+++ b/example/project/settings.py
@@ -53,6 +53,13 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "project.wsgi.application"
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "unique-snowflake",
+    }
+}
+
 
 DATABASES = {
     "default": {

--- a/example/unicorn/components/polling.py
+++ b/example/unicorn/components/polling.py
@@ -1,3 +1,5 @@
+import time
+
 from django.contrib import messages
 from django.utils.timezone import now
 
@@ -8,6 +10,11 @@ class PollingView(UnicornView):
     polling_disabled = False
     date_example = now()
     current_time = now()
+    counter = 0
+
+    def slow_update(self):
+        self.counter += 1
+        time.sleep(0.8)  # Simulate slow request
 
     def get_date(self):
         self.current_time = now()

--- a/example/unicorn/templates/unicorn/polling.html
+++ b/example/unicorn/templates/unicorn/polling.html
@@ -13,6 +13,9 @@
 
     current_time: {{ current_time|date:"s" }}
 
+    <br /><br/>
+    <button u:click="slow_update()">Increase counter: {{counter}}</button>
+
     <br /><br />
     <input unicorn:model="date_example" type="text" id="dateExampleId">
     date_example: {{ date_example }} | {{ date_example|date:"s" }}<br />

--- a/poetry.lock
+++ b/poetry.lock
@@ -278,6 +278,14 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "isort"
 version = "5.7.0"
 description = "A Python utility / library to sort Python imports."
@@ -321,14 +329,6 @@ python-versions = "*"
 
 [package.dependencies]
 django = ">=1.11.0"
-
-[[package]]
-name = "more-itertools"
-version = "8.6.0"
-description = "More routines for operating on iterables, beyond itertools"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
 
 [[package]]
 name = "mypy"
@@ -453,25 +453,24 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "5.4.3"
+version = "6.2.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=17.4.0"
+attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-more-itertools = ">=4.0.0"
+iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<1.0"
-py = ">=1.5.0"
-wcwidth = "*"
+pluggy = ">=0.12,<1.0.0a1"
+py = ">=1.8.2"
+toml = "*"
 
 [package.extras]
-checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
@@ -593,14 +592,6 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-name = "wcwidth"
-version = "0.2.5"
-description = "Measures the displayed width of unicode strings in a terminal"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "wrapt"
 version = "1.12.1"
 description = "Module for decorators, wrappers and monkey patching."
@@ -623,7 +614,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "870cb67a1dadc806342ba40223bedeb1283061074313eb414471848c66740dbd"
+content-hash = "5fc6dfe11bc5b7d13bbd5d3a8b9a9dcff1f18cc4d0a980fab3b973b0cf8926cf"
 
 [metadata.files]
 appdirs = [
@@ -761,6 +752,10 @@ importlib-metadata = [
     {file = "importlib_metadata-3.4.0-py3-none-any.whl", hash = "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771"},
     {file = "importlib_metadata-3.4.0.tar.gz", hash = "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"},
 ]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
 isort = [
     {file = "isort-5.7.0-py3-none-any.whl", hash = "sha256:fff4f0c04e1825522ce6949973e83110a6e907750cd92d128b0d14aaaadbffdc"},
     {file = "isort-5.7.0.tar.gz", hash = "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e"},
@@ -776,10 +771,6 @@ mock = [
 model-bakery = [
     {file = "model_bakery-1.0.2-py2.py3-none-any.whl", hash = "sha256:c05901b60d0e9f1a2823af1cdcbce5d1c67dcc1d0e4b8da3d5b6f9ea5706597d"},
     {file = "model_bakery-1.0.2.tar.gz", hash = "sha256:f0b94fde361abcabaf321c6bb62538aed3909c346ece35c628cb004ff1da6cdc"},
-]
-more-itertools = [
-    {file = "more-itertools-8.6.0.tar.gz", hash = "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf"},
-    {file = "more_itertools-8.6.0-py3-none-any.whl", hash = "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330"},
 ]
 mypy = [
     {file = "mypy-0.770-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:a34b577cdf6313bf24755f7a0e3f3c326d5c1f4fe7422d1d06498eb25ad0c600"},
@@ -879,8 +870,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
-    {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+    {file = "pytest-6.2.2-py3-none-any.whl", hash = "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"},
+    {file = "pytest-6.2.2.tar.gz", hash = "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9"},
 ]
 pytest-django = [
     {file = "pytest-django-3.10.0.tar.gz", hash = "sha256:4de6dbd077ed8606616958f77655fed0d5e3ee45159475671c7fa67596c6dba6"},
@@ -997,10 +988,6 @@ typing-extensions = [
 urllib3 = [
     {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},
     {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
-]
-wcwidth = [
-    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
-    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ wrapt = "^1.12.1"
 cachetools = "^4.1.1"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.4.3"
+pytest = "^6.2"
 black = "^19.10b0"
 flake8 = "^3.8.3"
 isort = "^5.0.9"
@@ -44,3 +44,12 @@ multi_line_output = 3
 include_trailing_comma = true
 skip_glob = "*/migrations/*.py"
 profile = "black"
+
+[tool.pytest.ini_options]
+addopts = "--quiet --failed-first --reuse-db --nomigrations -p no:warnings"
+testpaths = [
+    "tests"
+]
+markers = [
+    "slow: marks tests as slow",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ skip_glob = "*/migrations/*.py"
 profile = "black"
 
 [tool.pytest.ini_options]
-addopts = "--quiet --failed-first --reuse-db --nomigrations -p no:warnings"
+addopts = "--quiet --failed-first --reuse-db --nomigrations -p no:warnings -m 'not slow'"
 testpaths = [
     "tests"
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-addopts = --quiet --failed-first --reuse-db --nomigrations -p no:warnings
-testpaths =
-    tests

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,34 @@
+from django_unicorn.settings import get_cache_alias, get_serial_enabled, get_settings
+
+
+def test_settings_cache_alias(settings):
+    settings.UNICORN["CACHE_ALIAS"] = "unicorn_cache"
+
+    expected = "unicorn_cache"
+    actual = get_cache_alias()
+    assert expected == actual
+
+
+def test_settings_legacy(settings):
+    settings.DJANGO_UNICORN = {}
+    settings.DJANGO_UNICORN["CACHE_ALIAS"] = "unicorn_cache"
+
+    expected = "unicorn_cache"
+    actual = get_cache_alias()
+    assert expected == actual
+
+
+def test_get_serial_enabled(settings):
+    settings.UNICORN["SERIAL"]["ENABLED"] = False
+    assert get_serial_enabled() is False
+
+    settings.UNICORN["SERIAL"]["ENABLED"] = True
+    assert get_serial_enabled() is True
+
+    settings.UNICORN["SERIAL"]["ENABLED"] = True
+    settings.CACHES["unicorn_cache"] = {}
+    settings.CACHES["unicorn_cache"][
+        "BACKEND"
+    ] = "django.core.cache.backends.dummy.DummyCache"
+    settings.UNICORN["CACHE_ALIAS"] = "unicorn_cache"
+    assert get_serial_enabled() is False

--- a/tests/views/message/test_call_method.py
+++ b/tests/views/message/test_call_method.py
@@ -1,3 +1,5 @@
+import time
+
 import orjson
 import shortuuid
 
@@ -11,6 +13,7 @@ def test_message_call_method(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -31,6 +34,7 @@ def test_message_call_method_redirect(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -56,6 +60,7 @@ def test_message_call_method_refresh_redirect(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -82,6 +87,7 @@ def test_message_call_method_hash_update(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -105,6 +111,7 @@ def test_message_call_method_return_value(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -131,6 +138,7 @@ def test_message_call_method_poll_update(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -155,6 +163,7 @@ def test_message_call_method_setter(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -177,6 +186,7 @@ def test_message_call_method_nested_setter(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -199,6 +209,7 @@ def test_message_call_method_toggle(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -221,6 +232,7 @@ def test_message_call_method_nested_toggle(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -243,6 +255,7 @@ def test_message_call_method_params(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -265,6 +278,7 @@ def test_message_call_method_no_validation(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -287,6 +301,7 @@ def test_message_call_method_validation(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -313,6 +328,7 @@ def test_message_call_method_reset(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -336,6 +352,7 @@ def test_message_call_method_refresh(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(

--- a/tests/views/message/test_call_method_multiple.py
+++ b/tests/views/message/test_call_method_multiple.py
@@ -1,0 +1,296 @@
+import time
+from copy import deepcopy
+from multiprocessing.dummy import Pool as ThreadPool
+
+import orjson
+import pytest
+import shortuuid
+
+from django_unicorn.components import UnicornView
+from django_unicorn.utils import generate_checksum
+
+
+class FakeSlowComponent(UnicornView):
+    template_name = "templates/test_component.html"
+
+    counter = 0
+    another_thing = 0
+
+    def slow_action(self):
+        time.sleep(0.3)
+        self.counter += 1
+
+        return self.counter
+
+
+@pytest.mark.slow
+def test_message_call_method_single(client):
+    data = {"counter": 0}
+    component_id = shortuuid.uuid()[:8]
+    message = {
+        "actionQueue": [{"payload": {"name": "slow_action"}, "type": "callMethod",}],
+        "data": data,
+        "checksum": generate_checksum(orjson.dumps(data)),
+        "id": component_id,
+        "epoch": time.time(),  # assert there is an epoch (or set it in Python?)
+    }
+
+    response = client.post(
+        "/message/tests.views.message.test_call_method_multiple.FakeSlowComponent",
+        message,
+        content_type="application/json",
+    )
+
+    body = orjson.loads(response.content)
+    assert body["data"].get("counter") == 1
+
+
+def _message_runner(args):
+    client = args[0]
+    sleep_time = args[1]
+    message = args[2]
+    time.sleep(sleep_time)
+
+    # TODO: assert there is an epoch (or set it in Python?) in component request init
+    message["epoch"] = time.time()
+
+    response = client.post(
+        "/message/tests.views.message.test_call_method_multiple.FakeSlowComponent",
+        message,
+        content_type="application/json",
+    )
+    return response
+
+
+@pytest.mark.slow
+def test_message_call_method_two(client):
+    data = {"counter": 0}
+    component_id = shortuuid.uuid()[:8]
+    message = {
+        "actionQueue": [{"payload": {"name": "slow_action"}, "type": "callMethod",}],
+        "data": data,
+        "checksum": generate_checksum(orjson.dumps(data)),
+        "id": component_id,
+    }
+    messages = [(client, 0, message), (client, 0.1, message)]
+
+    with ThreadPool(len(messages)) as pool:
+        results = pool.map(_message_runner, messages)
+        assert len(results) == len(messages)
+
+        first_result = results[0]
+        first_body = orjson.loads(first_result.content)
+        # print("first_body", first_body)
+        assert first_body["data"].get("counter") == 2
+
+        second_result = results[1]
+        second_body = orjson.loads(second_result.content)
+        assert second_body["queued"] == True
+
+
+@pytest.mark.slow
+def test_message_call_method_multiple(client):
+    data = {"counter": 0}
+    component_id = shortuuid.uuid()[:8]
+    message = {
+        "actionQueue": [{"payload": {"name": "slow_action"}, "type": "callMethod",}],
+        "data": data,
+        "checksum": generate_checksum(orjson.dumps(data)),
+        "id": component_id,
+    }
+    messages = [(client, 0, message), (client, 0.1, message), (client, 0.2, message)]
+
+    with ThreadPool(len(messages)) as pool:
+        results = pool.map(_message_runner, messages)
+        assert len(results) == len(messages)
+
+        first_result = results[0]
+        first_body = orjson.loads(first_result.content)
+        assert first_body["data"].get("counter") == len(results)
+
+        for result in results[1:]:
+            result = results[1]
+            body = orjson.loads(result.content)
+            assert body.get("queued") == True
+
+
+@pytest.mark.slow
+<<<<<<< HEAD
+def test_message_call_method_multiple_with_updated_data(client):
+=======
+def test_message_multiple_return_is_correct(client, settings):
+    _set_serial(settings, True, 5)
+
+    data = {"counter": 0}
+    component_id = shortuuid.uuid()[:8]
+    message = {
+        "actionQueue": [{"payload": {"name": "slow_action"}, "type": "callMethod",}],
+        "data": data,
+        "checksum": generate_checksum(orjson.dumps(data)),
+        "id": component_id,
+    }
+    messages = [(client, 0, message), (client, 0.1, message), (client, 0.2, message)]
+
+    with ThreadPool(len(messages)) as pool:
+        results = pool.map(_message_runner, messages)
+        assert len(results) == len(messages)
+
+        first_result = results[0]
+        first_body = orjson.loads(first_result.content)
+        assert first_body["data"].get("counter") == len(results)
+        assert first_body["return"].get("value") == len(results)
+
+        for result in results[1:]:
+            result = results[1]
+            body = orjson.loads(result.content)
+            assert body.get("queued") == True
+
+
+@pytest.mark.slow
+def test_message_multiple_with_updated_data(client, settings):
+    """
+    Not sure how likely this is to happen, but if the data got changed in a new queued request
+    it gets disregarded because no sane way to merge it together. Not ideal, but not sure how to
+    handle it.
+    """
+    data = {"counter": 0}
+    component_id = shortuuid.uuid()[:8]
+    message = {
+        "actionQueue": [{"payload": {"name": "slow_action"}, "type": "callMethod",}],
+        "data": data,
+        "checksum": generate_checksum(orjson.dumps(data)),
+        "id": component_id,
+    }
+    messages = [(client, 0, message), (client, 0.1, message), (client, 0.2, message)]
+
+    # This new message with different data won't get used because not
+    # sure how to reconcile this with resulting data from queued messages
+    message_with_new_data = deepcopy(message)
+    message_with_new_data["data"] = {"counter": 7}
+    message_with_new_data["checksum"] = generate_checksum(
+        orjson.dumps(message_with_new_data["data"])
+    )
+    messages.append((client, 0.4, message_with_new_data))
+
+    with ThreadPool(len(messages)) as pool:
+        results = pool.map(_message_runner, messages)
+        assert len(results) == len(messages)
+
+        first_result = results[0]
+        first_body = orjson.loads(first_result.content)
+        assert first_body["data"].get("counter") == 4
+
+        for result in results[1:]:
+            result = results[1]
+            body = orjson.loads(result.content)
+            assert body.get("queued") == True
+
+
+@pytest.mark.slow
+def test_message_second_request_not_queued_because_after_first(client, settings):
+    _set_serial(settings, True, 5)
+
+    data = {"counter": 0}
+    component_id = shortuuid.uuid()[:8]
+    message = {
+        "actionQueue": [{"payload": {"name": "slow_action"}, "type": "callMethod",}],
+        "data": data,
+        "checksum": generate_checksum(orjson.dumps(data)),
+        "id": component_id,
+    }
+    messages = [(client, 0, message), (client, 0.4, message)]
+
+    with ThreadPool(len(messages)) as pool:
+        results = pool.map(_message_runner, messages)
+        assert len(results) == len(messages)
+
+        first_result = results[0]
+        first_body = orjson.loads(first_result.content)
+        assert first_body["data"].get("counter") == 1
+
+        second_result = results[1]
+        second_body = orjson.loads(second_result.content)
+        assert second_body["data"].get("counter") == 1
+
+
+@pytest.mark.slow
+def test_message_second_request_not_queued_because_serial_timeout(client, settings):
+    _set_serial(settings, True, 0.1)
+
+    data = {"counter": 0}
+    component_id = shortuuid.uuid()[:8]
+    message = {
+        "actionQueue": [{"payload": {"name": "slow_action"}, "type": "callMethod",}],
+        "data": data,
+        "checksum": generate_checksum(orjson.dumps(data)),
+        "id": component_id,
+    }
+    messages = [(client, 0, message), (client, 0.2, message)]
+
+    with ThreadPool(len(messages)) as pool:
+        results = pool.map(_message_runner, messages)
+        assert len(results) == len(messages)
+
+        first_result = results[0]
+        first_body = orjson.loads(first_result.content)
+        assert first_body["data"].get("counter") == 1
+
+        second_result = results[1]
+        second_body = orjson.loads(second_result.content)
+        assert second_body["data"].get("counter") == 1
+
+
+@pytest.mark.slow
+def test_message_second_request_not_queued_because_serial_disabled(client, settings):
+    _set_serial(settings, False, 5)
+
+    data = {"counter": 0}
+    component_id = shortuuid.uuid()[:8]
+    message = {
+        "actionQueue": [{"payload": {"name": "slow_action"}, "type": "callMethod",}],
+        "data": data,
+        "checksum": generate_checksum(orjson.dumps(data)),
+        "id": component_id,
+    }
+    messages = [(client, 0, message), (client, 0.2, message)]
+
+    with ThreadPool(len(messages)) as pool:
+        results = pool.map(_message_runner, messages)
+        assert len(results) == len(messages)
+
+        first_result = results[0]
+        first_body = orjson.loads(first_result.content)
+        assert first_body["data"].get("counter") == 1
+
+        second_result = results[1]
+        second_body = orjson.loads(second_result.content)
+        assert second_body["data"].get("counter") == 1
+
+
+@pytest.mark.slow
+def test_message_second_request_not_queued_because_dummy_cache(client, settings):
+    _set_serial(
+        settings, True, 5, cache_backend="django.core.cache.backends.dummy.DummyCache"
+    )
+
+    data = {"counter": 0}
+    component_id = shortuuid.uuid()[:8]
+    message = {
+        "actionQueue": [{"payload": {"name": "slow_action"}, "type": "callMethod",}],
+        "data": data,
+        "checksum": generate_checksum(orjson.dumps(data)),
+        "id": component_id,
+    }
+    messages = [(client, 0, message), (client, 0.2, message)]
+
+    with ThreadPool(len(messages)) as pool:
+        results = pool.map(_message_runner, messages)
+        assert len(results) == len(messages)
+
+        first_result = results[0]
+        first_body = orjson.loads(first_result.content)
+        assert first_body["data"].get("counter") == 1
+
+        second_result = results[1]
+        second_body = orjson.loads(second_result.content)
+        assert second_body["data"].get("counter") == 1

--- a/tests/views/message/test_call_method_multiple.py
+++ b/tests/views/message/test_call_method_multiple.py
@@ -40,8 +40,6 @@ def _message_runner(args):
     sleep_time = args[1]
     message = args[2]
     time.sleep(sleep_time)
-
-    # TODO: assert there is an epoch (or set it in Python?) in component request init
     message["epoch"] = time.time()
 
     response = client.post(
@@ -63,7 +61,7 @@ def test_message_single(client, settings):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": component_id,
-        "epoch": time.time(),  # assert there is an epoch (or set it in Python?)
+        "epoch": time.time(),
     }
 
     response = client.post(

--- a/tests/views/message/test_db_input.py
+++ b/tests/views/message/test_db_input.py
@@ -1,3 +1,5 @@
+import time
+
 import orjson
 import pytest
 import shortuuid
@@ -27,6 +29,7 @@ def test_message_db_input_update(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -81,6 +84,7 @@ def test_message_db_input_create(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     assert Flavor.objects.all().count() == 0

--- a/tests/views/message/test_message.py
+++ b/tests/views/message/test_message.py
@@ -1,3 +1,5 @@
+import time
+
 from django.http import JsonResponse
 
 import pytest
@@ -42,28 +44,53 @@ def test_message_no_data(client):
 
 
 def test_message_no_checksum(client):
-    data = {"data": {}, "id": "asdf"}
+    data = {
+        "data": {},
+        "id": "asdf",
+        "epoch": time.time(),
+    }
     response = post_json(client, data)
 
     assert_json_error(response, "Missing checksum")
 
 
 def test_message_bad_checksum(client):
-    data = {"data": {}, "checksum": "asdf", "id": "asdf"}
+    data = {
+        "data": {},
+        "checksum": "asdf",
+        "id": "asdf",
+        "epoch": time.time(),
+    }
     response = post_json(client, data)
 
     assert_json_error(response, "Checksum does not match")
 
 
 def test_message_no_component_id(client):
-    data = {"data": {}, "checksum": "FpZ5q8E2"}
+    data = {
+        "data": {},
+        "checksum": "FpZ5q8E2",
+        "epoch": time.time(),
+    }
     response = post_json(client, data)
 
     assert_json_error(response, "Missing component id")
 
 
+def test_message_no_epoch(client):
+    data = {"data": {}, "checksum": "FpZ5q8E2", "id": "abc"}
+    response = post_json(client, data)
+
+    assert_json_error(response, "Missing epoch")
+
+
 def test_message_component_not_found(client):
-    data = {"data": {}, "checksum": "FpZ5q8E2", "id": "asdf"}
+    data = {
+        "data": {},
+        "checksum": "FpZ5q8E2",
+        "id": "asdf",
+        "epoch": time.time(),
+    }
 
     with pytest.raises(ComponentLoadError) as e:
         post_json(client, data)
@@ -75,7 +102,12 @@ def test_message_component_not_found(client):
 
 
 def test_message_component_with_dash(client):
-    data = {"data": {}, "checksum": "FpZ5q8E2", "id": "asdf"}
+    data = {
+        "data": {},
+        "checksum": "FpZ5q8E2",
+        "id": "asdf",
+        "epoch": time.time(),
+    }
 
     with pytest.raises(ComponentLoadError) as e:
         post_json(client, data, url="/message/test-a")
@@ -87,7 +119,12 @@ def test_message_component_with_dash(client):
 
 
 def test_message_component_with_dot(client):
-    data = {"data": {}, "checksum": "FpZ5q8E2", "id": "asdf"}
+    data = {
+        "data": {},
+        "checksum": "FpZ5q8E2",
+        "id": "asdf",
+        "epoch": time.time(),
+    }
 
     with pytest.raises(ComponentLoadError) as e:
         post_json(client, data, url="/message/test.a")

--- a/tests/views/message/test_set_property.py
+++ b/tests/views/message/test_set_property.py
@@ -1,3 +1,5 @@
+import time
+
 import orjson
 import shortuuid
 
@@ -22,6 +24,7 @@ def test_setter(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     body = _post_message_and_get_body(client, message)
@@ -39,6 +42,7 @@ def test_nested_setter(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     body = _post_message_and_get_body(client, message)
@@ -59,6 +63,7 @@ def test_equal_sign(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     body = _post_message_and_get_body(client, message)

--- a/tests/views/message/test_sync_input.py
+++ b/tests/views/message/test_sync_input.py
@@ -1,3 +1,5 @@
+import time
+
 import orjson
 import shortuuid
 
@@ -16,6 +18,7 @@ def test_message_nested_sync_input(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(

--- a/tests/views/message/test_target.py
+++ b/tests/views/message/test_target.py
@@ -1,3 +1,5 @@
+import time
+
 import orjson
 import shortuuid
 from bs4 import BeautifulSoup
@@ -24,6 +26,7 @@ def test_message_generated_checksum_matches_dom_checksum(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -60,6 +63,7 @@ def test_message_target_invalid(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -88,6 +92,7 @@ def test_message_target_id(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -118,6 +123,7 @@ def test_message_target_only_id(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -148,6 +154,7 @@ def test_message_target_only_key(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(
@@ -178,6 +185,7 @@ def test_message_target_key(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     response = client.post(

--- a/tests/views/message/test_toggle.py
+++ b/tests/views/message/test_toggle.py
@@ -1,3 +1,5 @@
+import time
+
 import orjson
 import shortuuid
 
@@ -24,6 +26,7 @@ def test_message_toggle(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     body = _post_message_and_get_body(client, message)
@@ -41,6 +44,7 @@ def test_message_nested_toggle(client):
         "data": data,
         "checksum": generate_checksum(orjson.dumps(data)),
         "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
     }
 
     body = _post_message_and_get_body(client, message)


### PR DESCRIPTION
Not sure if this is a good idea or not and there are probably some edge cases to think through. Might even want a setting to enable this functionality.

Still missing is a way to merge the resulting data from the current request into the data stored in the next request that happened while the first was processing.

This PR is a potential solution for #117.