### PR TITLE
Add child `componentInit()` calls into the parent js initialization

### DIFF
--- a/tests/templatetags/test_unicorn_render.py
+++ b/tests/templatetags/test_unicorn_render.py
@@ -1,3 +1,5 @@
+import re
+
 from django.template.base import Token, TokenType
 
 from django_unicorn.components import UnicornView
@@ -175,3 +177,45 @@ def test_unicorn_render_id_use_pk():
     actual = unicorn_node.render(context)
 
     assert "==123==" in actual
+
+
+def test_unicorn_render_component_one_script_tag(settings):
+    settings.DEBUG = True
+    token = Token(
+        TokenType.TEXT,
+        "unicorn 'tests.templatetags.test_unicorn_render.FakeComponentKwargs'",
+    )
+    unicorn_node = unicorn(None, token)
+    context = {}
+    html = unicorn_node.render(context)
+
+    assert "<script" in html
+    assert len(re.findall("<script", html)) == 1
+
+
+def test_unicorn_render_child_component_no_script_tag(settings):
+    settings.DEBUG = True
+    token = Token(
+        TokenType.TEXT,
+        "unicorn 'tests.templatetags.test_unicorn_render.FakeComponentKwargs' parent=view",
+    )
+    unicorn_node = unicorn(None, token)
+    view = FakeComponentParent(component_name="test", component_id="asdf")
+    context = {"view": view}
+    html = unicorn_node.render(context)
+
+    assert "<script" not in html
+
+
+def test_unicorn_render_parent_component_one_script_tag(settings):
+    settings.DEBUG = True
+    token = Token(
+        TokenType.TEXT,
+        "unicorn 'tests.templatetags.test_unicorn_render.FakeComponentParent'",
+    )
+    unicorn_node = unicorn(None, token)
+    context = {}
+    html = unicorn_node.render(context)
+
+    assert "<script" in html
+    assert len(re.findall("<script", html)) == 1

--- a/tests/views/message/test_db_input.py
+++ b/tests/views/message/test_db_input.py
@@ -116,4 +116,3 @@ def test_message_db_input_create(client):
 
     assert not body["errors"]
     assert dicts_equal(expected, body["data"])
-


### PR DESCRIPTION
Child components don't need the whole script to initialize, they should just call `componentInit()` at the same place the parent component calls theirs.

This is a proof of concept so it needs some tests around it, but it seems to work fine with my example nested components.