### PR TITLE
use ast for parsing

### DIFF
--- a/django_unicorn/call_method_parser.py
+++ b/django_unicorn/call_method_parser.py
@@ -1,5 +1,5 @@
+import ast
 import logging
-from ast import literal_eval
 from typing import Any, Dict, List, Tuple
 from uuid import UUID
 
@@ -22,21 +22,32 @@ CASTERS = [
     lambda a: UUID(a),
 ]
 
-STOP_CHARACTERS = [":", ",", "]", "}", ")"]
-STRING_CHARACTERS = ["'", '"']
-
 
 class InvalidKwarg(Exception):
     pass
 
 
+def eval_arg(arg):
+    try:
+        arg = ast.literal_eval(arg)
+    except SyntaxError:
+        for caster in CASTERS:
+            try:
+                casted_value = caster(arg)
+
+                if casted_value:
+                    arg = casted_value
+                    break
+            except ValueError:
+                pass
+
+    return arg
+
+
 def parse_kwarg(kwarg: str, raise_if_unparseable=False) -> Dict[str, Any]:
     """
     Parses a potential kwarg as a string into a dictionary.
-
     For example: `parse_kwarg("test='1'")` == `{"test": "1"}`
-
-
     """
 
     parsed_kwarg = {}
@@ -70,7 +81,7 @@ def parse_kwarg(kwarg: str, raise_if_unparseable=False) -> Dict[str, Any]:
     # (the value can be a template variable that will get set from the context when
     # the templatetag is rendered in which case it can't be parsed in this manner)
     try:
-        val = parse_args(val)[0]
+        val = eval_arg(val)
     except ValueError:
         if raise_if_unparseable:
             raise
@@ -78,108 +89,6 @@ def parse_kwarg(kwarg: str, raise_if_unparseable=False) -> Dict[str, Any]:
     parsed_kwarg[key] = val
 
     return parsed_kwarg
-
-
-def parse_args(args: str) -> List[Any]:
-    """
-    Parses arguments as a string into Python objects.
-
-    For example: "'1'" would result in a "1". Or "[1, 2]" would result in [1, 2].
-
-    Handles strings, ints, floats, lists, tuples, dictionaries, sets, datetime, UUID.
-
-    Datetime is parsed with `parse_datetime`: https://docs.djangoproject.com/en/stable/ref/utils/#django.utils.dateparse.parse_datetime.
-    """
-    found_args = []
-    arg = ""
-
-    curly_bracket_count = 0
-    square_bracket_count = 0
-    parenthesis_count = 0
-
-    inside_string = False
-
-    def _eval_arg(_arg):
-        try:
-            _arg = literal_eval(_arg)
-        except SyntaxError:
-            for caster in CASTERS:
-                try:
-                    casted_value = caster(_arg)
-
-                    if casted_value:
-                        _arg = casted_value
-                        break
-                except ValueError:
-                    pass
-
-        return _arg
-
-    def _parse_arg(_arg):
-        if (
-            curly_bracket_count == 0
-            and square_bracket_count == 0
-            and parenthesis_count == 0
-        ):
-            _arg = _eval_arg(_arg)
-            found_args.append(_arg)
-            return ""
-
-        return _arg
-
-    for c in args:
-        if len(arg) > 1:
-            if c in STOP_CHARACTERS:
-                previous_char = arg[-1:][0]
-
-                if previous_char == "'":
-                    inside_string = False
-
-        if not inside_string and not c.strip():
-            continue
-
-        if (
-            c == ","
-            and not inside_string
-            and curly_bracket_count == 0
-            and square_bracket_count == 0
-            and parenthesis_count == 0
-        ):
-            if arg:
-                arg = _eval_arg(arg)
-                found_args.append(arg)
-                arg = ""
-
-            continue
-
-        arg += c
-
-        if c == "{":
-            curly_bracket_count += 1
-        elif c == "}":
-            curly_bracket_count -= 1
-            arg = _parse_arg(arg)
-        elif c == "[":
-            square_bracket_count += 1
-        elif c == "]":
-            square_bracket_count -= 1
-            arg = _parse_arg(arg)
-        elif c == "(":
-            parenthesis_count += 1
-        elif c == ")":
-            parenthesis_count -= 1
-            arg = _parse_arg(arg)
-        elif c in STRING_CHARACTERS:
-            inside_string = True
-
-    if arg:
-        if arg.startswith("'") and arg.endswith("'") and len(arg.split("'")) > 3:
-            arg = arg[1:-1]
-
-        arg = _eval_arg(arg)
-        found_args.append(arg)
-
-    return found_args
 
 
 def parse_call_method_name(call_method_name: str) -> Tuple[str, List[Any]]:
@@ -193,24 +102,28 @@ def parse_call_method_name(call_method_name: str) -> Tuple[str, List[Any]]:
         Tuple of method_name and a list of arguments.
     """
 
+    # Special function with "$" - remove before parsing with AST
+    if call_method_name.startswith("$"):
+        dollar_func = True
+        call_method_name = call_method_name[1:]
+    else:
+        dollar_func = False
+
+    tree = ast.parse(call_method_name, "eval")
     method_name = call_method_name
     params: List[Any] = []
+    kwargs: Dict[str, Any] = {}
 
-    if "(" in call_method_name and call_method_name.endswith(")"):
-        param_idx = call_method_name.index("(")
-        params_str = call_method_name[param_idx:]
+    if tree.body and isinstance(tree.body[0].value, ast.Call):
+        call = tree.body[0].value
+        method_name = call.func.id
+        params = [eval_arg(arg) for arg in call.args]
 
-        # Remove the arguments from the method name
-        method_name = call_method_name.replace(params_str, "")
+        # Not returned, but might be usable
+        kwargs = {kw.arg: eval_arg(kw.value) for kw in call.keywords}
 
-        # Remove parenthesis
-        params_str = params_str[1:-1]
-
-        if params_str == "":
-            return (method_name, params)
-
-        # Split up mutiple args
-        # TODO: Handle kwargs
-        params = parse_args(params_str)
+    # Insert "$" if spcial function
+    if dollar_func:
+        method_name = "$" + method_name
 
     return (method_name, params)

--- a/django_unicorn/call_method_parser.py
+++ b/django_unicorn/call_method_parser.py
@@ -122,7 +122,7 @@ def parse_call_method_name(call_method_name: str) -> Tuple[str, List[Any]]:
         # Not returned, but might be usable
         kwargs = {kw.arg: eval_arg(kw.value) for kw in call.keywords}
 
-    # Insert "$" if spcial function
+    # Insert "$" if special function
     if dollar_func:
         method_name = "$" + method_name
 

--- a/example/unicorn/templates/unicorn/text-inputs.html
+++ b/example/unicorn/templates/unicorn/text-inputs.html
@@ -22,7 +22,7 @@
     <input unicorn:model="name" u:partial.id="model-id" class="clean" unicorn:dirty.class.remove="clean" type="text" id="name" unicorn:key="key1">
 
     <div>
-        <span unicorn:key="model-key">Targeted by key: {{name}}</span> | <span id="model-id">Targeted by id: {{name}}</span> | <span id="">Not targeted by id: {{name}}</span> | 
+        <span unicorn:key="model-key">Targeted by key: {{name}}</span> | <span id="model-id">Targeted by id: {{name}}</span> | <span id="">Not targeted by id: {{name}}</span> |
     </div>
 
     <label>Duplicate id</label>
@@ -42,7 +42,7 @@
 
     <label>Lazy</label>
     <input unicorn:model.lazy="name" unicorn:dirty.class="dirty" type="text" id="lazyName" unicorn:key="key1">
-    
+
     <label>Debounce-1000</label>
     <input unicorn:model.debounce-1000="name" unicorn:dirty.class="dirty" type="text" id="debounceName" unicorn:key="key1">
 
@@ -60,6 +60,7 @@
     <button unicorn:click="set_name()">set_name()</button>
     <button unicorn:click="set_name('')">set_name('')</button>
     <button unicorn:click="set_name('blob 2')">set_name('blob 2')</button>
+    <button unicorn:click="set_name('abc{}.def')">set_name('abc{}.def')</button>
     <button unicorn:click="name='human'">name='human'</button>
 
     <br /><br />

--- a/tests/call_method_parser/test_parse_args.py
+++ b/tests/call_method_parser/test_parse_args.py
@@ -1,13 +1,14 @@
+from datetime import datetime
 from uuid import UUID
 
 import pytest
 
-from django_unicorn.call_method_parser import parse_args
+from django_unicorn.call_method_parser import eval_arg
 
 
 def test_args():
-    expected = [1, 2]
-    actual = parse_args("1, 2")
+    expected = (1, 2)
+    actual = eval_arg("1, 2")
 
     assert actual == expected
     assert isinstance(actual[0], int)
@@ -15,32 +16,32 @@ def test_args():
 
 
 def test_single_quote_str_arg():
-    expected = ["1"]
-    actual = parse_args("'1'")
+    expected = ("1")
+    actual = eval_arg("'1'")
 
     assert actual == expected
     assert isinstance(actual[0], str)
 
 
 def test_str_with_space_arg():
-    expected = ["django unicorn"]
-    actual = parse_args("'django unicorn'")
+    expected = ("django unicorn")
+    actual = eval_arg("'django unicorn'")
 
     assert actual == expected
     assert isinstance(actual[0], str)
 
 
 def test_str_with_extra_single_quote():
-    expected = ["django's unicorn"]
-    actual = parse_args("'django's unicorn'")
+    expected = ("django's unicorn")
+    actual = eval_arg("'django\\'s unicorn'")
 
     assert actual == expected
     assert isinstance(actual[0], str)
 
 
 def test_str_with_extra_double_quote():
-    expected = ['django "unicorn"']
-    actual = parse_args("'django \"unicorn\"'")
+    expected = ('django "unicorn"')
+    actual = eval_arg("'django \"unicorn\"'")
 
     assert actual == expected
     assert isinstance(actual[0], str)
@@ -48,8 +49,8 @@ def test_str_with_extra_double_quote():
 
 @pytest.mark.skip("These are edge cases, but still are broken")
 def test_str_with_comma():
-    expected = ["a', b"]
-    actual = parse_args("'a', b'")
+    expected = ("a', b")
+    actual = eval_arg("'a', b'")
 
     assert actual == expected
     assert isinstance(actual[0], str)
@@ -57,40 +58,40 @@ def test_str_with_comma():
 
 @pytest.mark.skip("These are edge cases, but still are broken")
 def test_str_with_stop_character():
-    expected = ["a'} b"]
-    actual = parse_args("'a'} b'")
+    expected = ("a'} b")
+    actual = eval_arg("'a'} b'")
 
     assert actual == expected
     assert isinstance(actual[0], str)
 
 
 def test_double_quote_str_arg():
-    expected = ["string"]
-    actual = parse_args('"string"')
+    expected = ("string")
+    actual = eval_arg('"string"')
 
     assert actual == expected
     assert isinstance(actual[0], str)
 
 
 def test_args_with_single_quote_dict():
-    expected = [1, {"2": 3}]
-    actual = parse_args("1, {'2': 3}")
+    expected = (1, {"2": 3})
+    actual = eval_arg("1, {'2': 3}")
 
     assert actual == expected
     assert isinstance(actual[1], dict)
 
 
 def test_args_with_double_quote_dict():
-    expected = [1, {"2": 3}]
-    actual = parse_args('1, {"2": 3}')
+    expected = (1, {"2": 3})
+    actual = eval_arg('1, {"2": 3}')
 
     assert actual == expected
     assert isinstance(actual[1], dict)
 
 
 def test_args_with_nested_dict():
-    expected = [1, {"2": {"3": 4}}]
-    actual = parse_args("1, {'2': { '3': 4 }}")
+    expected = (1, {"2": {"3": 4}})
+    actual = eval_arg("1, {'2': { '3': 4 }}")
 
     assert actual == expected
     assert isinstance(actual[1], dict)
@@ -98,63 +99,60 @@ def test_args_with_nested_dict():
 
 
 def test_args_with_nested_list_3():
-    expected = [[1, ["2", "3"], 4], 9]
-    actual = parse_args("[1, ['2', '3'], 4], 9")
+    expected = ([1, ["2", "3"], 4], 9)
+    actual = eval_arg("[1, ['2', '3'], 4], 9")
 
     assert actual == expected
 
 
 def test_args_with_nested_tuple():
-    expected = [9, (1, ("2", "3"), 4)]
-    actual = parse_args("9, (1, ('2', '3'), 4)")
+    expected = (9, (1, ("2", "3"), 4))
+    actual = eval_arg("9, (1, ('2', '3'), 4)")
 
     assert actual == expected
 
 
 def test_args_with_nested_objects():
-    expected = [[0, 1], {"2 2": {"3": 4}}, (5, 6, [7, 8])]
-    actual = parse_args("[0,  1], {'2 2': { '3': 4 }}, (5, 6, [7, 8])")
+    expected = ([0, 1], {"2 2": {"3": 4}}, (5, 6, [7, 8]))
+    actual = eval_arg("[0,  1], {'2 2': { '3': 4 }}, (5, 6, [7, 8])")
 
     assert actual == expected
 
 
 def test_list_args():
-    expected = [1, [2, "3"]]
-    actual = parse_args("1, [2, '3']")
+    expected = (1, [2, "3"])
+    actual = eval_arg("1, [2, '3']")
 
     assert actual == expected
-
-
-from datetime import datetime
 
 
 def test_datetime():
-    expected = [datetime(2020, 9, 12, 1, 1, 1)]
-    actual = parse_args("2020-09-12T01:01:01")
+    expected = datetime(2020, 9, 12, 1, 1, 1)
+    actual = eval_arg("2020-09-12T01:01:01")
 
     assert actual == expected
-    assert isinstance(actual[0], datetime)
+    assert isinstance(actual, datetime)
 
 
 def test_uuid():
-    expected = [UUID("90144cb9-fc47-476d-b124-d543b0cff091")]
-    actual = parse_args("90144cb9-fc47-476d-b124-d543b0cff091")
+    expected = UUID("90144cb9-fc47-476d-b124-d543b0cff091")
+    actual = eval_arg("90144cb9-fc47-476d-b124-d543b0cff091")
 
     assert actual == expected
-    assert isinstance(actual[0], UUID)
+    assert isinstance(actual, UUID)
 
 
 def test_float():
-    expected = [[1, 5.4]]
-    actual = parse_args("[1, 5.4]")
+    expected = [1, 5.4]
+    actual = eval_arg("[1, 5.4]")
 
     assert actual == expected
-    assert isinstance(actual[0][1], float)
+    assert isinstance(actual[1], float)
 
 
 def test_set():
-    expected = [{1, 5}]
-    actual = parse_args("{1, 5}")
+    expected = {1, 5}
+    actual = eval_arg("{1, 5}")
 
     assert actual == expected
-    assert isinstance(actual[0], set)
+    assert isinstance(actual, set)

--- a/tests/call_method_parser/test_parse_call_method_name.py
+++ b/tests/call_method_parser/test_parse_call_method_name.py
@@ -30,8 +30,15 @@ def test_multiple_args():
     assert actual == expected
 
 
+def test_var_with_curly_braces():
+    expected = ("set_name", ["{}", ])
+    actual = parse_call_method_name('set_name("{}")')
+
+    assert actual == expected
+
+
 def test_one_arg():
-    expected = ("set_name", ["1",])
+    expected = ("set_name", ["1", ])
     actual = parse_call_method_name('set_name("1")')
 
     assert actual == expected


### PR DESCRIPTION
During testing I found that this currently does not work in 0.18.1:

```html
 <button unicorn:click="set_name('abc{}.def')">
```
and we get the error:

_set_name() takes 2 positional arguments but 3 were given_

I tried to look into the code and did not easily see how the custom parser could be fixed, so I have made an attempt to switch to using the ast module instead.

This PR should be considered a first attempt and I would appreciate any feedback. I do not have knowledge of all the code base so I do not know if anything else will break with this, but at least all the tests now runs, with some modifactions. 