### PR TITLE
dataclasses dependency for 3.6 and test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ orjson = "^3.2.1"
 shortuuid = "^1.0.1"
 wrapt = "^1.12.1"
 cachetools = "^4.1.1"
+dataclasses = {version = "^0.8.0", python = "<3.7"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"

--- a/tests/views/test_unicorn_dataclass.py
+++ b/tests/views/test_unicorn_dataclass.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+from django_unicorn.components import UnicornView
+from django_unicorn.views import _set_property_value
+
+
+@dataclass
+class InventoryItem:
+    """Class for keeping track of an item in inventory."""
+    name: str
+    unit_price: float
+    quantity_on_hand: int = 0
+
+
+class NestedPropertyView(UnicornView):
+    inventory = InventoryItem("Hammer", 20)
+
+
+def test_set_property_value_dataclass():
+    component = NestedPropertyView(component_name="test", component_id="12345678")
+    assert InventoryItem("Hammer", 20) == component.inventory
+
+    _set_property_value(
+        component, "inventory",
+        InventoryItem("Hammer", 20, 1),
+        {"inventory": InventoryItem("Hammer", 20, 1)}
+    )
+
+    assert InventoryItem("Hammer", 20, 1) == component.inventory


### PR DESCRIPTION
I had some problems with the latest release on python 3.6, related to the added support for dataclasses.

I'm not totally sure what the problems are, since it worked locally, most likely because the dataclasses backport is a dependency for pydantic (which is only a dev dependency).

So maybe it is ok to add dataclasses as a dependency for python 3.6? I also added a simple test for dataclasses, although I have never used them myself.