### PR TITLE
Fixed errors raised during setting attributes for models in `views/utils.py`

### DIFF
--- a/django_unicorn/views/utils.py
+++ b/django_unicorn/views/utils.py
@@ -1,5 +1,5 @@
 from dataclasses import is_dataclass
-from typing import Any, Union
+from typing import Any, Iterable, Union
 
 from django.db.models import Model
 from django.db import models
@@ -13,6 +13,8 @@ from django_unicorn.utils import get_type_hints
 def set_property_for_model(model: Model, name: str, value: Any) -> None:
     if attr := getattr(model, name, None):
         if isinstance(attr, models.Manager) and hasattr(attr, 'set'):
+            if not isinstance(value, Iterable):
+                value = [value]
             attr.set(value)
             return
     if name == 'pk':


### PR DESCRIPTION
- Fixed bugs regarding setting model fields
- Fixed bugs relating using `setattr` with `ManyToMany` and `ManyToOne` relations instead of calling their `set()` method
- Fixed errors regarding setting Foreignkey value using only primary key

## Problem  
I found bugs regarding setting values for models in `set_property_from_data` in `views/utils.py`.
Though the problem is not one easily found, My app tended to result in errors asking to call the `set` method of a many to one field (reverse foreignkey) rather that set the values directly.
I also found that one model I had that depended on a custom user model, was having errors raised because it did not have a `name` attribute

```python3
@timed
def set_property_from_data(
    component_or_field: Union[UnicornView, UnicornField, Model], name: str, value: Any,
) -> None:
    """
    Sets properties on the component based on passed-in data.
    """

    if not hasattr(component_or_field, name):
        return
    if isinstance(component_or_field, Model):
        set_property_for_model(component_or_field, name,value = value)
        return

    field = getattr(component_or_field, name)
    component_field_is_model_or_unicorn_field = _is_component_field_model_or_unicorn_field(
        component_or_field, name
    )

    # UnicornField and Models are always a dictionary (can be nested)
    if component_field_is_model_or_unicorn_field:
        # Re-get the field since it might have been set in `_is_component_field_model_or_unicorn_field`
        field = getattr(component_or_field, name)

        if isinstance(value, dict):
            for key in value.keys():
                key_value = value[key]
                set_property_from_data(field, key, key_value)
        else:
            set_property_from_data(field, field.name, value)            #<---Problem if Model has no name attribute.
    else:
        type_hints = get_type_hints(component_or_field)

        if name in type_hints:
            # Construct the specified type by passing the value in
            # Usually the value will be a string (because it is coming from JSON)
            # and basic types can be constructed by passing in a string,
            # i.e. int("1") or float("1.1")

            if is_dataclass(type_hints[name]):
                value = type_hints[name](**value)
            else:
                value = type_hints[name](value)
                

        if hasattr(component_or_field, "_set_property"):
            # Can assume that `component_or_field` is a component
            component_or_field._set_property(name, value)
        else:
            setattr(component_or_field, name, value)                #<---- Problem source Many relation field.
```

To fix this I found it necessary to implement a separate helper function to handle model assignments that could take care of all the problem cases.