### PR TITLE
call poll method immediately on focus

### DIFF
--- a/django_unicorn/static/js/component.js
+++ b/django_unicorn/static/js/component.js
@@ -328,6 +328,15 @@ export class Component {
               clearInterval(this.poll.timer);
             }
           } else {
+            // tab gets focus -> call poll method once and
+            // start polling at intervals
+            if (this.isPollEnabled()) {
+              this.callMethod(
+                this.poll.method,
+                this.poll.partials,
+                this.handlePollError
+              );
+            }
             this.startPolling();
           }
         },


### PR DESCRIPTION
I'm using a large polling interval (~ 10 seconds) for some pages, where the user tends to move to another page, and then come back to check if there is a result.

If I understand the code correctly, moving away from the page will disable polling, and when focusing the page again it will always init the polling with the polling interval **before** calling the poll function and user then some times executes a manual refresh and sees that there is indeed a result.

Not sure if it applies to all use cases, but I propose to execute the call method immediately on focus.

The code in this PR solves this for my use case, but please give feedback if there are any concerns of problems this might cause.