### PR TITLE
Use node filter to skip nested components when walking

### DIFF
--- a/django_unicorn/static/unicorn/js/component.js
+++ b/django_unicorn/static/unicorn/js/component.js
@@ -8,7 +8,7 @@ import {
 import { components } from "./store.js";
 import { send } from "./messageSender.js";
 import morphdom from "./morphdom/2.6.1/morphdom.js";
-import { $, hasValue, isEmpty, isFunction, walk } from "./utils.js";
+import { $, hasValue, isEmpty, isFunction, walk, FilterSkipNested } from "./utils.js";
 
 /**
  * Encapsulate component.
@@ -169,10 +169,6 @@ export class Component {
           // Skip the component root element
           return;
         }
-        if (el.getAttribute("unicorn:checksum")) {
-          // Skip nested components
-          throw Error();
-        }
 
         const element = new Element(el);
 
@@ -240,7 +236,7 @@ export class Component {
             }
           });
         }
-      });
+      }, FilterSkipNested);
     } catch (err) {
       // nothing
     }

--- a/django_unicorn/static/unicorn/js/component.js
+++ b/django_unicorn/static/unicorn/js/component.js
@@ -8,7 +8,14 @@ import {
 import { components } from "./store.js";
 import { send } from "./messageSender.js";
 import morphdom from "./morphdom/2.6.1/morphdom.js";
-import { $, hasValue, isEmpty, isFunction, walk, FilterSkipNested } from "./utils.js";
+import {
+  $,
+  hasValue,
+  isEmpty,
+  isFunction,
+  walk,
+  FilterSkipNested,
+} from "./utils.js";
 
 /**
  * Encapsulate component.
@@ -164,79 +171,83 @@ export class Component {
     this.dbEls = [];
 
     try {
-      this.walker(this.root, (el) => {
-        if (el.isSameNode(this.root)) {
-          // Skip the component root element
-          return;
-        }
-
-        const element = new Element(el);
-
-        if (element.isUnicorn) {
-          if (hasValue(element.field) && hasValue(element.db)) {
-            if (!this.attachedDbEvents.some((e) => e.isSame(element))) {
-              this.attachedDbEvents.push(element);
-              addDbEventListener(this, element);
-
-              // If a field is lazy, also add an event listener for input for dirty states
-              if (element.field.isLazy) {
-                // This input event for isLazy will be stopped after dirty is checked when the event fires
-                addDbEventListener(this, element, "input");
-              }
-            }
-
-            if (!this.dbEls.some((e) => e.isSame(element))) {
-              this.dbEls.push(element);
-            }
-          } else if (
-            hasValue(element.model) &&
-            isEmpty(element.db) &&
-            isEmpty(element.field)
-          ) {
-            if (!this.attachedModelEvents.some((e) => e.isSame(element))) {
-              this.attachedModelEvents.push(element);
-              addModelEventListener(this, element);
-
-              // If a model is lazy, also add an event listener for input for dirty states
-              if (element.model.isLazy) {
-                // This input event for isLazy will be stopped after dirty is checked when the event fires
-                addModelEventListener(this, element, "input");
-              }
-            }
-
-            if (!this.modelEls.some((e) => e.isSame(element))) {
-              this.modelEls.push(element);
-            }
-          } else if (hasValue(element.loading)) {
-            this.loadingEls.push(element);
-
-            // Hide loading elements that are shown when an action happens
-            if (element.loading.show) {
-              element.hide();
-            }
+      this.walker(
+        this.root,
+        (el) => {
+          if (el.isSameNode(this.root)) {
+            // Skip the component root element
+            return;
           }
 
-          if (hasValue(element.key)) {
-            this.keyEls.push(element);
-          }
+          const element = new Element(el);
 
-          element.actions.forEach((action) => {
-            if (this.actionEvents[action.eventType]) {
-              this.actionEvents[action.eventType].push({ action, element });
-            } else {
-              this.actionEvents[action.eventType] = [{ action, element }];
+          if (element.isUnicorn) {
+            if (hasValue(element.field) && hasValue(element.db)) {
+              if (!this.attachedDbEvents.some((e) => e.isSame(element))) {
+                this.attachedDbEvents.push(element);
+                addDbEventListener(this, element);
 
-              if (
-                !this.attachedEventTypes.some((et) => et === action.eventType)
-              ) {
-                this.attachedEventTypes.push(action.eventType);
-                addActionEventListener(this, action.eventType);
-                element.events.push(action.eventType);
+                // If a field is lazy, also add an event listener for input for dirty states
+                if (element.field.isLazy) {
+                  // This input event for isLazy will be stopped after dirty is checked when the event fires
+                  addDbEventListener(this, element, "input");
+                }
+              }
+
+              if (!this.dbEls.some((e) => e.isSame(element))) {
+                this.dbEls.push(element);
+              }
+            } else if (
+              hasValue(element.model) &&
+              isEmpty(element.db) &&
+              isEmpty(element.field)
+            ) {
+              if (!this.attachedModelEvents.some((e) => e.isSame(element))) {
+                this.attachedModelEvents.push(element);
+                addModelEventListener(this, element);
+
+                // If a model is lazy, also add an event listener for input for dirty states
+                if (element.model.isLazy) {
+                  // This input event for isLazy will be stopped after dirty is checked when the event fires
+                  addModelEventListener(this, element, "input");
+                }
+              }
+
+              if (!this.modelEls.some((e) => e.isSame(element))) {
+                this.modelEls.push(element);
+              }
+            } else if (hasValue(element.loading)) {
+              this.loadingEls.push(element);
+
+              // Hide loading elements that are shown when an action happens
+              if (element.loading.show) {
+                element.hide();
               }
             }
-          });
-        }
-      }, FilterSkipNested);
+
+            if (hasValue(element.key)) {
+              this.keyEls.push(element);
+            }
+
+            element.actions.forEach((action) => {
+              if (this.actionEvents[action.eventType]) {
+                this.actionEvents[action.eventType].push({ action, element });
+              } else {
+                this.actionEvents[action.eventType] = [{ action, element }];
+
+                if (
+                  !this.attachedEventTypes.some((et) => et === action.eventType)
+                ) {
+                  this.attachedEventTypes.push(action.eventType);
+                  addActionEventListener(this, action.eventType);
+                  element.events.push(action.eventType);
+                }
+              }
+            });
+          }
+        },
+        FilterSkipNested
+      );
     } catch (err) {
       // nothing
     }

--- a/django_unicorn/static/unicorn/js/utils.js
+++ b/django_unicorn/static/unicorn/js/utils.js
@@ -105,13 +105,33 @@ export function toKebabCase(str) {
 }
 
 /**
+ * Filter to accept any element (use with walk) 
+ */
+ export const FilterAny = {
+  acceptNode: (node) => NodeFilter.FILTER_ACCEPT
+}
+
+/**
+ * Filter to skip nested components (use with walk)
+ */
+export const FilterSkipNested = {
+  acceptNode: (node) => {
+    if (node.getAttribute("unicorn:checksum")) {
+      // with a tree walker, child nodes are also rejected
+      return NodeFilter.FILTER_REJECT;
+    }
+    return NodeFilter.FILTER_ACCEPT;
+  }
+}
+
+/**
  * Traverses the DOM looking for child elements.
  */
-export function walk(el, callback) {
+export function walk(el, callback, filter=FilterAny) {
   const walker = document.createTreeWalker(
     el,
     NodeFilter.SHOW_ELEMENT,
-    null,
+    filter,
     false
   );
 

--- a/django_unicorn/static/unicorn/js/utils.js
+++ b/django_unicorn/static/unicorn/js/utils.js
@@ -105,11 +105,11 @@ export function toKebabCase(str) {
 }
 
 /**
- * Filter to accept any element (use with walk) 
+ * Filter to accept any element (use with walk)
  */
- export const FilterAny = {
-  acceptNode: (node) => NodeFilter.FILTER_ACCEPT
-}
+export const FilterAny = {
+  acceptNode: (node) => NodeFilter.FILTER_ACCEPT,
+};
 
 /**
  * Filter to skip nested components (use with walk)
@@ -121,13 +121,13 @@ export const FilterSkipNested = {
       return NodeFilter.FILTER_REJECT;
     }
     return NodeFilter.FILTER_ACCEPT;
-  }
-}
+  },
+};
 
 /**
  * Traverses the DOM looking for child elements.
  */
-export function walk(el, callback, filter=FilterAny) {
+export function walk(el, callback, filter = FilterAny) {
   const walker = document.createTreeWalker(
     el,
     NodeFilter.SHOW_ELEMENT,

--- a/example/unicorn/templates/unicorn/nested/table.html
+++ b/example/unicorn/templates/unicorn/nested/table.html
@@ -32,4 +32,6 @@
         {% endfor %}
     </table>
 
+    <button unicorn:click="load_table">Load table</button>
+
 </div>

--- a/tests/js/utils.js
+++ b/tests/js/utils.js
@@ -4,6 +4,15 @@ import { Element } from "../../django_unicorn/static/unicorn/js/element.js";
 import { Component } from "../../django_unicorn/static/unicorn/js/component.js";
 
 /**
+ * Mock some browser globals using a fake DOM
+ */
+export function setBrowserMocks() {
+  const dom = new JSDOM("<div></div>");
+  global.document = dom.window.document;
+  global.NodeFilter = dom.window.NodeFilter;
+}
+
+/**
  * Gets a fake DOM document based on the passed-in HTML fragement.
  * @param {String} html HTML fragment.
  */

--- a/tests/js/utils/walk.test.js
+++ b/tests/js/utils/walk.test.js
@@ -1,0 +1,62 @@
+import test from "ava";
+import {
+  FilterAny,
+  FilterSkipNested,
+  walk,
+} from "../../../django_unicorn/static/unicorn/js/utils";
+import { getEl, setBrowserMocks } from "../utils.js";
+
+// makes a document and NodeFilter available from a fake DOM
+setBrowserMocks();
+
+test("walk any", (t) => {
+  const componentRootHtml = `
+<div unicorn:id="5jypjiyb" unicorn:name="text-inputs" unicorn:checksum="GXzew3Km">
+  <input unicorn:model="name" type="text" id="name">
+  <div
+    unicorn:id="5jypjiyb:nested.filter"
+    unicorn:name="nested.filter"
+    unicorn:key=""
+    unicorn:checksum="KtgR7WTb"
+  >
+    <input type="text" unicorn:model="search" id="search" />
+  </div>
+  <input unicorn:model="name" type="text" id="name2">
+</div>
+  `;
+  const componentRoot = getEl(componentRootHtml);
+  const nodes = [];
+
+  walk(componentRoot, (node) => nodes.push(node), FilterAny);
+
+  t.is(nodes.length, 4);
+  t.is(nodes[0].getAttribute("id"), "name");
+  t.is(nodes[1].getAttribute("unicorn:id"), "5jypjiyb:nested.filter");
+  t.is(nodes[2].getAttribute("id"), "search");
+  t.is(nodes[3].getAttribute("id"), "name2");
+});
+
+test("walk skip nested", (t) => {
+  const componentRootHtml = `
+<div unicorn:id="5jypjiyb" unicorn:name="text-inputs" unicorn:checksum="GXzew3Km">
+  <input unicorn:model="name" type="text" id="name">
+  <div
+    unicorn:id="5jypjiyb:nested.filter"
+    unicorn:name="nested.filter"
+    unicorn:key=""
+    unicorn:checksum="KtgR7WTb"
+  >
+    <input type="text" unicorn:model="search" id="search" />
+  </div>
+  <input unicorn:model="name" type="text" id="name2">
+</div>
+  `;
+  const componentRoot = getEl(componentRootHtml);
+  const nodes = [];
+
+  walk(componentRoot, (node) => nodes.push(node), FilterSkipNested);
+
+  t.is(nodes.length, 2);
+  t.is(nodes[0].getAttribute("id"), "name");
+  t.is(nodes[1].getAttribute("id"), "name2");
+});


### PR DESCRIPTION
For #261, instead of breaking out of the walker use a [NodeFilter](https://developer.mozilla.org/en-US/docs/Web/API/NodeFilter) to reject the top element of a nested component (using same logic if element has got a `unicorn:checksum` attr). 

When used with a tree walker rejecting a node from the filter skips the current node plus any descendants. In context of the `refreshEventListeners` function it achieves the same thing as before by not traversing a nested component, but continues to walk any elements that might come after it.