### PR TITLE
Use rindex when handling installed app that points to an app config

### DIFF
--- a/django_unicorn/components/unicorn_view.py
+++ b/django_unicorn/components/unicorn_view.py
@@ -91,7 +91,7 @@ def get_locations(component_name):
     for app in unicorn_apps:
         # Handle an installed app that actually points to an app config
         if ".apps." in app:
-            app_config_idx = app.index(".apps.")
+            app_config_idx = app.rindex(".apps.")
             app = app[:app_config_idx]
 
         app_module_name = f"{app}.components.{module_name}"

--- a/tests/components/test_get_locations.py
+++ b/tests/components/test_get_locations.py
@@ -29,7 +29,6 @@ def test_get_locations_fully_qualified_with_dots():
         ("HelloWorldView", "project.components.hello_world"),
     ]
     actual = get_locations("project.components.hello_world.HelloWorldView")
-    print(actual)
 
     assert expected == actual
 
@@ -118,10 +117,17 @@ def test_get_locations_apps_setting_invalid(settings):
 def test_get_locations_installed_app_with_app_config(settings):
     unicorn_apps = settings.UNICORN["APPS"]
     del settings.UNICORN["APPS"]
-    settings.INSTALLED_APPS = ("example.coffee.apps.Config",)
+    settings.INSTALLED_APPS = ["example.coffee.apps.Config",]
 
     expected = [("HelloWorldView", "example.coffee.components.hello_world",)]
     actual = get_locations("hello-world")
 
     assert expected == actual
+
+    # test when the app is in a subdirectory "apps"
+    settings.INSTALLED_APPS[0] = "foo_project.apps.bar_app.apps.Config"
+    expected_location = [("FooBarView", "foo_project.apps.bar_app.components.foo_bar")]
+    actual_location = get_locations("foo-bar")
+    assert expected_location == actual_location
+
     settings.UNICORN["APPS"] = unicorn_apps


### PR DESCRIPTION
Fixes #267 

I think this should fix the issue.

@adamghill - Do let me know if there is a better way to test an app in `INSTALLED_APPS` that doesn't actually exist.