### PR TITLE
be more verbose when components can't be loaded

### DIFF
--- a/django_unicorn/components/unicorn_view.py
+++ b/django_unicorn/components/unicorn_view.py
@@ -773,5 +773,5 @@ class UnicornView(TemplateView):
                 last_exception = e
 
         raise ComponentLoadError(
-            f"'{component_name}' component could not be loaded."
+            f"'{component_name}' component could not be loaded:\n    {last_exception}"
         ) from last_exception


### PR DESCRIPTION
There is only the message `django_unicorn.errors.ComponentLoadError: 'foo' component could not be loaded`. But it's hard to see where the problem is. This patch adds the message from the original exception to the output..
fixes #277 