### PR TITLE
Minify response

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -32,6 +32,7 @@ def pytest_configure():
         "SERIAL": {"ENABLED": True, "TIMEOUT": 5},
         "CACHE_ALIAS": "default",
         "APPS": ("unicorn",),
+        "MINIFY_HTML": False,
     }
 
     caches = {

--- a/django_unicorn/components/unicorn_template_response.py
+++ b/django_unicorn/components/unicorn_template_response.py
@@ -8,6 +8,7 @@ from bs4.dammit import EntitySubstitution
 from bs4.element import Tag
 from bs4.formatter import HTMLFormatter
 
+from django_unicorn.settings import get_minify_html_enabled
 from django_unicorn.utils import sanitize_html
 
 from ..decorators import timed
@@ -122,6 +123,15 @@ class UnicornTemplateResponse(TemplateResponse):
         self.component.rendered(rendered_template)
 
         response.content = rendered_template
+
+        if get_minify_html_enabled():
+            # Import here in case the minify extra was not installed
+            from htmlmin import minify
+
+            minified_html = minify(response.content.decode())
+
+            if len(minified_html) < len(rendered_template):
+                response.content = minified_html
 
         return response
 

--- a/django_unicorn/settings.py
+++ b/django_unicorn/settings.py
@@ -1,4 +1,9 @@
+import logging
+
 from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
 
 
 SETTINGS_KEY = "UNICORN"
@@ -53,3 +58,19 @@ def get_serial_timeout():
     Default serial timeout is 60 seconds.
     """
     return get_serial_settings().get("TIMEOUT", 60)
+
+
+def get_minify_html_enabled():
+    minify_html_enabled = get_setting("MINIFY_HTML", False)
+
+    if minify_html_enabled:
+        try:
+            import htmlmin
+        except ModuleNotFoundError:
+            logger.error(
+                "MINIFY_HTML is `True`, but minify extra could not be imported. Install with `unicorn[minify]`."
+            )
+
+            return False
+
+    return minify_html_enabled

--- a/django_unicorn/views/__init__.py
+++ b/django_unicorn/views/__init__.py
@@ -484,4 +484,4 @@ def message(request: HttpRequest, component_name: str = None) -> JsonResponse:
     component_request = ComponentRequest(request, component_name)
     json_result = _handle_component_request(request, component_request)
 
-    return JsonResponse(json_result)
+    return JsonResponse(json_result, json_dumps_params={"separators": (",", ":")})

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ import nox
 @nox.parametrize("django", ["2.2", "3.0", "3.2"])
 def tests(session, django):
     session.install("poetry")
-    session.run("poetry", "install")
+    session.run("poetry", "install", "-E", "minify")
     session.install(f"django=={django}")
     session.run("pytest", "-m", "not slow")
     session.run("pytest", "-m", "slow")

--- a/poetry.lock
+++ b/poetry.lock
@@ -371,6 +371,14 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 docs = ["sphinx"]
 
 [[package]]
+name = "htmlmin"
+version = "0.1.12"
+description = "An HTML Minifier"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -861,7 +869,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "70590b704fa9df2eaa78c70bf43aa5a6ed41a18900eb7b3522483255e70ce5d0"
+content-hash = "61fb74806659907e4563e7faa4a91f20c5fa7c5cd7aa061a2d38b57c54bf3c48"
 
 [metadata.files]
 argcomplete = [
@@ -1054,6 +1062,9 @@ greenlet = [
     {file = "greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf"},
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
+]
+htmlmin = [
+    {file = "htmlmin-0.1.12.tar.gz", hash = "sha256:50c1ef4630374a5d723900096a961cff426dff46b48f34d194a81bbe14eca178"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -36,17 +36,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.2.0"
+version = "21.3.0"
 description = "Classes Without Boilerplate"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
 
 [[package]]
 name = "backports.cached-property"
@@ -58,21 +58,6 @@ python-versions = ">=3.6.0"
 
 [package.dependencies]
 typing = {version = ">=3.6", markers = "python_version < \"3.7\""}
-
-[[package]]
-name = "backports.entry-points-selectable"
-version = "1.1.1"
-description = "Compatibility shim providing selectable entry points for older implementations"
-category = "dev"
-optional = false
-python-versions = ">=2.7"
-
-[package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
 
 [[package]]
 name = "beautifulsoup4"
@@ -335,7 +320,7 @@ pytz = "*"
 
 [[package]]
 name = "filelock"
-version = "3.4.0"
+version = "3.4.1"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
@@ -375,7 +360,7 @@ name = "htmlmin"
 version = "0.1.12"
 description = "An HTML Minifier"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -702,16 +687,19 @@ python-versions = "*"
 
 [[package]]
 name = "redis"
-version = "4.0.2"
+version = "4.1.0"
 description = "Python client for Redis database and key-value store"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-deprecated = "*"
+deprecated = ">=1.2.3"
+importlib-metadata = {version = ">=1.0", markers = "python_version < \"3.8\""}
+packaging = ">=21.3"
 
 [package.extras]
+cryptography = ["cryptography (>=36.0.1)", "requests (>=2.26.0)"]
 hiredis = ["hiredis (>=1.0.0)"]
 
 [[package]]
@@ -782,11 +770,11 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "tomlkit"
-version = "0.7.2"
+version = "0.8.0"
 description = "Style preserving TOML library"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6,<4.0"
 
 [[package]]
 name = "typed-ast"
@@ -827,14 +815,13 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.10.0"
+version = "20.11.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
-"backports.entry-points-selectable" = ">=1.0.4"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.2,<4"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
@@ -866,10 +853,13 @@ python-versions = ">=3.6"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
+[extras]
+minify = ["htmlmin"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "61fb74806659907e4563e7faa4a91f20c5fa7c5cd7aa061a2d38b57c54bf3c48"
+content-hash = "6d45615303bc4cac2b8af045f28c96234c7747f3f77eff06e838b377a6e9bd1d"
 
 [metadata.files]
 argcomplete = [
@@ -885,16 +875,12 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
-    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+    {file = "attrs-21.3.0-py2.py3-none-any.whl", hash = "sha256:8f7335278dedd26b58c38e006338242cc0977f06d51579b2b8b87b9b33bff66c"},
+    {file = "attrs-21.3.0.tar.gz", hash = "sha256:50f3c9b216dc9021042f71b392859a773b904ce1a029077f58f6598272432045"},
 ]
 "backports.cached-property" = [
     {file = "backports.cached-property-1.0.1.tar.gz", hash = "sha256:1a5ef1e750f8bc7d0204c807aae8e0f450c655be0cf4b30407a35fd4bb27186c"},
     {file = "backports.cached_property-1.0.1-py3-none-any.whl", hash = "sha256:687b5fe14be40aadcf547cae91337a1fdb84026046a39370274e54d3fe4fb4f9"},
-]
-"backports.entry-points-selectable" = [
-    {file = "backports.entry_points_selectable-1.1.1-py2.py3-none-any.whl", hash = "sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b"},
-    {file = "backports.entry_points_selectable-1.1.1.tar.gz", hash = "sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386"},
 ]
 beautifulsoup4 = [
     {file = "beautifulsoup4-4.10.0-py3-none-any.whl", hash = "sha256:9a315ce70049920ea4572a4055bc4bd700c940521d36fc858205ad4fcde149bf"},
@@ -999,8 +985,8 @@ djangorestframework = [
     {file = "djangorestframework-3.13.1.tar.gz", hash = "sha256:0c33407ce23acc68eca2a6e46424b008c9c02eceb8cf18581921d0092bc1f2ee"},
 ]
 filelock = [
-    {file = "filelock-3.4.0-py3-none-any.whl", hash = "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8"},
-    {file = "filelock-3.4.0.tar.gz", hash = "sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4"},
+    {file = "filelock-3.4.1-py3-none-any.whl", hash = "sha256:a4bc51381e01502a30e9f06dd4fa19a1712eab852b6fb0f84fd7cce0793d8ca3"},
+    {file = "filelock-3.4.1.tar.gz", hash = "sha256:0f12f552b42b5bf60dba233710bf71337d35494fc8bdd4fd6d9f6d082ad45e06"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -1235,8 +1221,8 @@ pywatchman = [
     {file = "pywatchman-1.4.1.tar.gz", hash = "sha256:d0047eb275deafb0011eda0a1a815fbd9742478c3d2b5ad6956d300e447dc2f9"},
 ]
 redis = [
-    {file = "redis-4.0.2-py3-none-any.whl", hash = "sha256:c8481cf414474e3497ec7971a1ba9b998c8efad0f0d289a009a5bbef040894f9"},
-    {file = "redis-4.0.2.tar.gz", hash = "sha256:ccf692811f2c1fc7a92b466aa2599e4a6d2d73d5f736a2c70be600657c0da34a"},
+    {file = "redis-4.1.0-py3-none-any.whl", hash = "sha256:e13fad67c098a33141bacde872786960e86a5c97a4255009bcd43c795fa1cc77"},
+    {file = "redis-4.1.0.tar.gz", hash = "sha256:21f0a23bce707909076e6ba2ce076cba59bff60d2ab22972e0647fdf620ffe47"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
@@ -1267,8 +1253,8 @@ tomli = [
     {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.7.2-py2.py3-none-any.whl", hash = "sha256:173ad840fa5d2aac140528ca1933c29791b79a374a0861a80347f42ec9328117"},
-    {file = "tomlkit-0.7.2.tar.gz", hash = "sha256:d7a454f319a7e9bd2e249f239168729327e4dd2d27b17dc68be264ad1ce36754"},
+    {file = "tomlkit-0.8.0-py3-none-any.whl", hash = "sha256:b824e3466f1d475b2b5f1c392954c6cb7ea04d64354ff7300dc7c14257dc85db"},
+    {file = "tomlkit-0.8.0.tar.gz", hash = "sha256:29e84a855712dfe0e88a48f6d05c21118dbafb283bb2eed614d46f80deb8e9a1"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
@@ -1315,8 +1301,8 @@ urllib3 = [
     {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.10.0-py2.py3-none-any.whl", hash = "sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814"},
-    {file = "virtualenv-20.10.0.tar.gz", hash = "sha256:576d05b46eace16a9c348085f7d0dc8ef28713a2cabaa1cf0aea41e8f12c9218"},
+    {file = "virtualenv-20.11.1-py2.py3-none-any.whl", hash = "sha256:43973fb93cf1d04ec00a190f5e062919798a0fec94daaafcb4db1eda1aa8f340"},
+    {file = "virtualenv-20.11.1.tar.gz", hash = "sha256:17f26e9d0c4350d9df713d41077b2b3344cba59e104306e4105c8c75deeddcf7"},
 ]
 wrapt = [
     {file = "wrapt-1.13.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ shortuuid = "^1.0.1"
 cachetools = "^4.1.1"
 dataclasses = {version = "^0.8.0", python = "<3.7"}
 decorator = "^4.4.2"
+htmlmin = { version = "^0.1.12", optional = true }
+
+[tool.poetry.extras]
+minify = ["htmlmin"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"

--- a/tests/templatetags/test_unicorn_render.py
+++ b/tests/templatetags/test_unicorn_render.py
@@ -244,6 +244,23 @@ def test_unicorn_render_component_one_script_tag(settings):
     assert len(re.findall('<script type="module"', html)) == 1
 
 
+def test_unicorn_render_component_minify_html(settings):
+    settings.DEBUG = True
+    settings.UNICORN["MINIFY_HTML"] = True
+    token = Token(
+        TokenType.TEXT,
+        "unicorn 'tests.templatetags.test_unicorn_render.FakeComponentKwargs'",
+    )
+    unicorn_node = unicorn(Parser([]), token)
+    context = {}
+    html = unicorn_node.render(Context(context))
+
+    assert "<script type=module" in html
+    assert len(re.findall("<script type=module", html)) == 1
+
+    settings.UNICORN["MINIFY_HTML"] = False
+
+
 def test_unicorn_render_child_component_no_script_tag(settings):
     settings.DEBUG = True
     token = Token(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,8 @@
-from django_unicorn.settings import get_cache_alias, get_serial_enabled, get_settings
+from django_unicorn.settings import (
+    get_cache_alias,
+    get_minify_html_enabled,
+    get_serial_enabled,
+)
 
 
 def test_settings_cache_alias(settings):
@@ -32,3 +36,17 @@ def test_get_serial_enabled(settings):
     ] = "django.core.cache.backends.dummy.DummyCache"
     settings.UNICORN["CACHE_ALIAS"] = "unicorn_cache"
     assert get_serial_enabled() is False
+
+
+def test_settings_minify_html_false(settings):
+    settings.UNICORN["MINIFY_HTML"] = False
+
+    assert get_minify_html_enabled() is False
+
+
+def test_settings_minify_html_true(settings):
+    settings.UNICORN["MINIFY_HTML"] = True
+
+    assert get_minify_html_enabled() is True
+
+    settings.UNICORN["MINIFY_HTML"] = False


### PR DESCRIPTION
Includes:
- condense the JSON returned in the AJAX response
- add optional compression of HTML in the AJAX response

More details about HTML compression:
I tried both [`minify-html`](https://github.com/wilsonzlin/minify-html) and [`html-min`](https://htmlmin.readthedocs.io/) libraries for compressing the HTML.

Even with the sanest config options I could find for `minify-html` the HTML would get rendered a little weird sometimes and (I think) morphdom would lose the ability to morph from the initial HTML to the newly returned HTML. I tried this:
```
minified_html = minify(
    rendered_template,
    do_not_minify_doctype=True,
    ensure_spec_compliant_unquoted_attribute_values=True,
    keep_closing_tags=True,
    keep_html_and_head_opening_tags=True,
    keep_spaces_between_attributes=True,
    keep_comments=True,
    minify_css=False,
    minify_js=False,
    remove_bangs=False,
    remove_processing_instructions=False,
)
```

However, all my testing with `htmlmin` seems to point to it being a good middle ground between no compression at all and the extreme of `minify-html`. It is a little slower as well based on some simple benchmarking.

# First test
## initial response size
len(response.content): 1940

## minifiy with minify-html
The execution time is: 0.0005080699920654297
len(minify_html_value): 1826

## minify with `htmlmin`
The execution time is: 0.0005886554718017578
len(htmlmin_value): 1864

# Second test
## initial response size
len(response.content): 1504

## minifiy with minify-html
The execution time is: 0.0002880096435546875
len(minify_html_value): 1396

## minify with `htmlmin`
The execution time is: 0.0013859272003173828
len(htmlmin_value): 1434

Additional tests were basically the same as the above.

I think `htmlmin` is relatively safe to enable based on my testing, but I'm going to keep it behind a setting for now to see if it causes any issues for others.