### PR TITLE
Remove calling `orjson.dumps` before every data checksum

### DIFF
--- a/django_unicorn/components/unicorn_template_response.py
+++ b/django_unicorn/components/unicorn_template_response.py
@@ -116,7 +116,7 @@ class UnicornTemplateResponse(TemplateResponse):
 
         frontend_context_variables = self.component.get_frontend_context_variables()
         frontend_context_variables_dict = orjson.loads(frontend_context_variables)
-        checksum = generate_checksum(orjson.dumps(frontend_context_variables_dict))
+        checksum = generate_checksum(str(frontend_context_variables_dict))
 
         soup = BeautifulSoup(content, features="html.parser")
         root_element = get_root_element(soup)

--- a/django_unicorn/views/__init__.py
+++ b/django_unicorn/views/__init__.py
@@ -216,7 +216,7 @@ def _process_component_request(
         "data": updated_data,
         "errors": component.errors,
         "calls": component.calls,
-        "checksum": generate_checksum(orjson.dumps(component_request.data)),
+        "checksum": generate_checksum(str(component_request.data)),
     }
 
     if partial_doms:
@@ -270,7 +270,7 @@ def _process_component_request(
         parent_frontend_context_variables = loads(
             parent_component.get_frontend_context_variables()
         )
-        parent_checksum = generate_checksum(dumps(parent_frontend_context_variables))
+        parent_checksum = generate_checksum(str(parent_frontend_context_variables))
 
         parent = {
             "id": parent_component.component_id,

--- a/django_unicorn/views/objects.py
+++ b/django_unicorn/views/objects.py
@@ -76,7 +76,7 @@ class ComponentRequest:
         checksum = self.body.get("checksum")
         assert checksum, "Missing checksum"
 
-        generated_checksum = generate_checksum(dumps(self.data, fix_floats=False))
+        generated_checksum = generate_checksum(str(self.data))
         assert checksum == generated_checksum, "Checksum does not match"
 
 

--- a/tests/views/fake_components.py
+++ b/tests/views/fake_components.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Dict
 
 from django import forms
 from django.shortcuts import redirect
@@ -82,3 +83,11 @@ class FakeValidationComponent(UnicornView):
 
     def set_number(self, number):
         self.number = number
+
+
+class FakeComponentWithDictionary(UnicornView):
+    template_name = "templates/test_component.html"
+    dictionary: Dict = None
+
+    def test_method(self):
+        pass

--- a/tests/views/message/test_call_method.py
+++ b/tests/views/message/test_call_method.py
@@ -25,6 +25,32 @@ def test_message_call_method(client):
     assert response["data"].get("method_count") == 1
 
 
+def test_message_call_method_with_dictionary_checksum(client):
+    data = {"dictionary": {"1": "test", "2": "anothertest", "3": "", "4": "moretest"}}
+    message = {
+        "actionQueue": [
+            {
+                "payload": {"name": "test_method"},
+                "type": "callMethod",
+            }
+        ],
+        "data": data,
+        "checksum": generate_checksum(str(data)),
+        "id": shortuuid.uuid()[:8],
+        "epoch": time.time(),
+    }
+
+    response = client.post(
+        "/message/tests.views.fake_components.FakeComponentWithDictionary",
+        message,
+        content_type="application/json",
+    )
+
+    body = orjson.loads(response.content)
+
+    assert not body["errors"]
+
+
 def test_message_call_method_redirect(client):
     data = {}
     message = {
@@ -35,7 +61,7 @@ def test_message_call_method_redirect(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -64,7 +90,7 @@ def test_message_call_method_refresh_redirect(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -94,7 +120,7 @@ def test_message_call_method_hash_update(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -121,7 +147,7 @@ def test_message_call_method_return_value(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -152,7 +178,7 @@ def test_message_call_method_poll_update(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -182,7 +208,7 @@ def test_message_call_method_setter(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -208,7 +234,7 @@ def test_message_call_method_nested_setter(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -234,7 +260,7 @@ def test_message_call_method_multiple_nested_setter(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -260,7 +286,7 @@ def test_message_call_method_toggle(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -286,7 +312,7 @@ def test_message_call_method_nested_toggle(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -312,7 +338,7 @@ def test_message_call_method_args(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -338,7 +364,7 @@ def test_message_call_method_kwargs(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -364,7 +390,7 @@ def test_message_call_method_no_validation(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -390,7 +416,7 @@ def test_message_call_method_validation(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -420,7 +446,7 @@ def test_message_call_method_reset(client):
             },
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -449,7 +475,7 @@ def test_message_call_method_refresh(client):
             },
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }

--- a/tests/views/message/test_call_method_multiple.py
+++ b/tests/views/message/test_call_method_multiple.py
@@ -64,7 +64,7 @@ def test_message_single(client, settings):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": component_id,
         "epoch": time.time(),
     }
@@ -93,7 +93,7 @@ def test_message_two(client, settings):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": component_id,
     }
     messages = [(client, 0, message), (client, 0.1, message)]
@@ -125,7 +125,7 @@ def test_message_multiple(client, settings):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": component_id,
     }
     messages = [(client, 0, message), (client, 0.1, message), (client, 0.2, message)]
@@ -158,7 +158,7 @@ def test_message_multiple_return_is_correct(client, settings):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": component_id,
     }
     messages = [(client, 0, message), (client, 0.1, message), (client, 0.2, message)]
@@ -197,7 +197,7 @@ def test_message_multiple_with_updated_data(client, settings):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": component_id,
     }
     messages = [(client, 0, message), (client, 0.1, message), (client, 0.2, message)]
@@ -207,7 +207,7 @@ def test_message_multiple_with_updated_data(client, settings):
     message_with_new_data = deepcopy(message)
     message_with_new_data["data"] = {"counter": 7}
     message_with_new_data["checksum"] = generate_checksum(
-        orjson.dumps(message_with_new_data["data"])
+        str(message_with_new_data["data"])
     )
     messages.append((client, 0.4, message_with_new_data))
 
@@ -239,7 +239,7 @@ def test_message_second_request_not_queued_because_after_first(client, settings)
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": component_id,
     }
     messages = [(client, 0, message), (client, 0.4, message)]
@@ -271,7 +271,7 @@ def test_message_second_request_not_queued_because_serial_timeout(client, settin
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": component_id,
     }
     messages = [(client, 0, message), (client, 0.2, message)]
@@ -303,7 +303,7 @@ def test_message_second_request_not_queued_because_serial_disabled(client, setti
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": component_id,
     }
     messages = [(client, 0, message), (client, 0.2, message)]
@@ -338,7 +338,7 @@ def test_message_second_request_not_queued_because_dummy_cache(client, settings)
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": component_id,
     }
     messages = [(client, 0, message), (client, 0.2, message)]

--- a/tests/views/message/test_set_property.py
+++ b/tests/views/message/test_set_property.py
@@ -24,7 +24,7 @@ def test_setter(client):
             {"type": "callMethod", "payload": {"name": "check=True"}},
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -32,7 +32,7 @@ def test_setter(client):
     body = _post_message_and_get_body(client, message)
 
     assert not body["errors"]
-    assert body["data"]["check"] == True
+    assert body["data"]["check"] is True
 
 
 def test_nested_setter(client):
@@ -42,7 +42,7 @@ def test_nested_setter(client):
             {"type": "callMethod", "payload": {"name": "nested.check=True"}},
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -50,7 +50,7 @@ def test_nested_setter(client):
     body = _post_message_and_get_body(client, message)
 
     assert not body["errors"]
-    assert body["data"]["nested"]["check"] == True
+    assert body["data"]["nested"]["check"] is True
 
 
 def test_equal_sign(client):
@@ -63,7 +63,7 @@ def test_equal_sign(client):
             },
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }

--- a/tests/views/message/test_target.py
+++ b/tests/views/message/test_target.py
@@ -28,7 +28,7 @@ def test_message_generated_checksum_matches_dom_checksum(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -65,7 +65,7 @@ def test_message_target_invalid(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -94,7 +94,7 @@ def test_message_target_id(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -125,7 +125,7 @@ def test_message_target_only_id(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -156,7 +156,7 @@ def test_message_target_only_key(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -187,7 +187,7 @@ def test_message_target_key(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }

--- a/tests/views/message/test_toggle.py
+++ b/tests/views/message/test_toggle.py
@@ -24,7 +24,7 @@ def test_message_toggle(client):
             {"type": "callMethod", "payload": {"name": "$toggle('check')"}},
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -42,7 +42,7 @@ def test_message_nested_toggle(client):
             {"type": "callMethod", "payload": {"name": "$toggle('nested.check')"}},
         ],
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }

--- a/tests/views/message/utils.py
+++ b/tests/views/message/utils.py
@@ -1,6 +1,5 @@
 import time
 
-import orjson
 import shortuuid
 
 from django_unicorn.utils import generate_checksum
@@ -19,7 +18,7 @@ def post_and_get_response(
     message = {
         "actionQueue": action_queue,
         "data": data,
-        "checksum": generate_checksum(orjson.dumps(data)),
+        "checksum": generate_checksum(str(data)),
         "id": component_id,
         "epoch": time.time(),
         "hash": hash,


### PR DESCRIPTION
1. Fixes a bug where dictionary keys were sorted differently which would change the generated checksum.
2. Should remove some processing time on every render that was happening unnecessarily.