### PR TITLE
Fixes for argument mutations when calling view methods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,17 @@
 root = true
 
 [*]
-end_of_line = lf // Helps keep Windows, Mac, Linux on the same page since they handle end of line differently
+# Helps keep Windows, Mac, Linux on the same page since they handle end of line differently
+end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true // Auto-trims trailing whitespace
-insert_final_newline = true // Auto-adds a blank newline to the end of a file
+# Auto-trims trailing whitespace
+trim_trailing_whitespace = true
+# Auto-adds a blank newline to the end of a file
+insert_final_newline = true
 
 [*.scss]
-indent_size = 2 // More common to see 2 spaces in SCSS, HTML, and JS 
+# More common to see 2 spaces in SCSS, HTML, and JS
+indent_size = 2
 
 [*.html]
 indent_size = 2

--- a/django_unicorn/call_method_parser.py
+++ b/django_unicorn/call_method_parser.py
@@ -131,7 +131,9 @@ def parse_kwarg(kwarg: str, raise_if_unparseable=False) -> Dict[str, Any]:
 
 
 @lru_cache(maxsize=128, typed=True)
-def parse_call_method_name(call_method_name: str) -> Tuple[str, Tuple[Any], Mapping[str, Any]]:
+def parse_call_method_name(
+    call_method_name: str,
+) -> Tuple[str, Tuple[Any], Mapping[str, Any]]:
     """
     Parses the method name from the request payload into a set of parameters to pass to a method.
 

--- a/django_unicorn/call_method_parser.py
+++ b/django_unicorn/call_method_parser.py
@@ -1,7 +1,8 @@
 import ast
 import logging
 from functools import lru_cache
-from typing import Any, Dict, List, Tuple
+from types import MappingProxyType
+from typing import Any, Dict, List, Tuple, Mapping
 from uuid import UUID
 
 from django.utils.dateparse import (
@@ -130,15 +131,16 @@ def parse_kwarg(kwarg: str, raise_if_unparseable=False) -> Dict[str, Any]:
 
 
 @lru_cache(maxsize=128, typed=True)
-def parse_call_method_name(call_method_name: str) -> Tuple[str, List[Any]]:
+def parse_call_method_name(call_method_name: str) -> Tuple[str, Tuple[Any], Mapping[str, Any]]:
     """
     Parses the method name from the request payload into a set of parameters to pass to a method.
 
     Args:
-        param call_method_name: String representation of a method name with parameters, e.g. "set_name('Bob')"
+        param call_method_name: String representation of a method name with parameters,
+            e.g. "set_name('Bob')"
 
     Returns:
-        Tuple of method_name and a list of arguments.
+        Tuple of method_name, a list of arguments and a dict of keyword arguments
     """
 
     is_special_method = False
@@ -164,4 +166,5 @@ def parse_call_method_name(call_method_name: str) -> Tuple[str, List[Any]]:
     if is_special_method:
         method_name = f"${method_name}"
 
-    return (method_name, args, kwargs)
+    # conversion to immutable types - tuple and MappingProxyType
+    return method_name, tuple(args), MappingProxyType(kwargs)

--- a/django_unicorn/call_method_parser.py
+++ b/django_unicorn/call_method_parser.py
@@ -2,7 +2,7 @@ import ast
 import logging
 from functools import lru_cache
 from types import MappingProxyType
-from typing import Any, Dict, List, Tuple, Mapping
+from typing import Any, Dict, List, Mapping, Tuple
 from uuid import UUID
 
 from django.utils.dateparse import (

--- a/django_unicorn/views/objects.py
+++ b/django_unicorn/views/objects.py
@@ -23,8 +23,10 @@ class Action:
         self.partials = data.get("partials", [])
 
     def __repr__(self):
-        return (f"Action(action_type='{self.action_type}' payload={self.payload}"
-                f" partials={self.partials})")
+        return (
+            f"Action(action_type='{self.action_type}' payload={self.payload}"
+            f" partials={self.partials})"
+        )
 
 
 class ComponentRequest:
@@ -65,8 +67,10 @@ class ComponentRequest:
             self.action_queue.append(Action(action_data))
 
     def __repr__(self):
-        return (f"ComponentRequest(name='{self.name}' id='{self.id}' key='{self.key}'"
-                f" epoch={self.epoch} data={self.data} action_queue={self.action_queue})")
+        return (
+            f"ComponentRequest(name='{self.name}' id='{self.id}' key='{self.key}'"
+            f" epoch={self.epoch} data={self.data} action_queue={self.action_queue})"
+        )
 
     def validate_checksum(self):
         """

--- a/django_unicorn/views/objects.py
+++ b/django_unicorn/views/objects.py
@@ -23,7 +23,8 @@ class Action:
         self.partials = data.get("partials", [])
 
     def __repr__(self):
-        return f"Action(action_type='{self.action_type}' payload={self.payload} partials={self.partials})"
+        return (f"Action(action_type='{self.action_type}' payload={self.payload}"
+                f" partials={self.partials})")
 
 
 class ComponentRequest:
@@ -64,7 +65,8 @@ class ComponentRequest:
             self.action_queue.append(Action(action_data))
 
     def __repr__(self):
-        return f"ComponentRequest(name='{self.name}' id='{self.id}' key='{self.key}' epoch={self.epoch} data={self.data} action_queue={self.action_queue})"
+        return (f"ComponentRequest(name='{self.name}' id='{self.id}' key='{self.key}'"
+                f" epoch={self.epoch} data={self.data} action_queue={self.action_queue})")
 
     def validate_checksum(self):
         """
@@ -81,10 +83,10 @@ class ComponentRequest:
 
 
 class Return:
-    def __init__(self, method_name, args=[], kwargs={}):
+    def __init__(self, method_name, args=None, kwargs=None):
         self.method_name = method_name
-        self.args = args
-        self.kwargs = kwargs
+        self.args = args or []
+        self.kwargs = kwargs or {}
         self._value = {}
         self.redirect = {}
         self.poll = {}

--- a/example/unicorn/components/models.py
+++ b/example/unicorn/components/models.py
@@ -31,5 +31,8 @@ class ModelsView(UnicornView):
     def available_tastes(self):
         return Taste.objects.all()
 
+    def model_typehint(self, flavor: Flavor):
+        print(flavor)
+
     class Meta:
         javascript_exclude = ("flavor.taste_set",)

--- a/example/unicorn/templates/unicorn/models.html
+++ b/example/unicorn/templates/unicorn/models.html
@@ -1,77 +1,79 @@
 <div>
-    <style>
-        .dirty {
-            border: red 1px solid !important;
-        }
-    </style>
+  <style>
+    .dirty {
+      border: red 1px solid !important;
+    }
+
+  </style>
+
+  <div>
+    <h3>Using unicorn:model with Django models</h3>
 
     <div>
-        <h3>Using unicorn:model with Django models</h3>
+      <div>
+        <label>Name</label>
+        <input type="text" unicorn:model="flavor.name"></input>
+      </div>
 
-        <div>
-            <div>
-                <label>Name</label>
-                <input type="text" unicorn:model="flavor.name"></input>
-            </div>
-            
-            <div>
-                <label>Label</label>
-                <input type="text" unicorn:model="flavor.label"></input>
-            </div>
+      <div>
+        <label>Label</label>
+        <input type="text" unicorn:model="flavor.label"></input>
+      </div>
 
-            <button unicorn:click="save_flavor">save_flavor</button>
+      <button unicorn:click="save_flavor">save_flavor</button>
 
-            {% for flavor in flavors %}
-            <div>
-                <h4>{{ flavor.pk }}</h4>
-                <label>Name</label>
-                <input type="text" unicorn:model="flavors.{{ forloop.counter0 }}.name" u:dirty.class="dirty"></input>
-                {{ flavor.name }}
-                <br />
+      {% for flavor in flavors %}
+      <div>
+        <h4>{{ flavor.pk }}</h4>
+        <label>Name</label>
+        <input type="text" unicorn:model="flavors.{{ forloop.counter0 }}.name" u:dirty.class="dirty"></input>
+        {{ flavor.name }}
+        <br />
 
-                <label>Label</label>
-                <input type="text" unicorn:model="flavors.{{ forloop.counter0 }}.label" u:dirty.class="dirty"></input>
-                {{ flavor.label }}
-                <br />
+        <label>Label</label>
+        <input type="text" unicorn:model="flavors.{{ forloop.counter0 }}.label" u:dirty.class="dirty"></input>
+        {{ flavor.label }}
+        <br />
 
-                <label>Float</label>
-                <input type="text" unicorn:model="flavors.{{ forloop.counter0 }}.float_value"></input>
-                {{ flavor.float_value }}
-                <br />
+        <label>Float</label>
+        <input type="text" unicorn:model="flavors.{{ forloop.counter0 }}.float_value"></input>
+        {{ flavor.float_value }}
+        <br />
 
-                <label>Decimal value</label>
-                <input type="text" unicorn:model="flavors.{{ forloop.counter0 }}.decimal_value"></input>
-                {{ flavor.decimal_value }}
-                <br />
+        <label>Decimal value</label>
+        <input type="text" unicorn:model="flavors.{{ forloop.counter0 }}.decimal_value"></input>
+        {{ flavor.decimal_value }}
+        <br />
 
-                <label>Parent</label>
-                <select unicorn:model="flavors.{{ forloop.counter0 }}.parent">
-                    <option value="">n/a</option>
-                    {% for available_flavor in available_flavors %}
-                    <option value="{{ available_flavor.pk }}">{{ available_flavor.name }}</option>
-                    {% endfor %}
-                </select>
-                {{ flavor.parent.name }}
-                <br />
+        <label>Parent</label>
+        <select unicorn:model="flavors.{{ forloop.counter0 }}.parent">
+          <option value="">n/a</option>
+          {% for available_flavor in available_flavors %}
+          <option value="{{ available_flavor.pk }}">{{ available_flavor.name }}</option>
+          {% endfor %}
+        </select>
+        {{ flavor.parent.name }}
+        <br />
 
-                <label>Taste</label>
-                <select unicorn:model="flavors.{{ forloop.counter0 }}.taste_set" multiple>
-                    {% for available_taste in available_tastes %}
-                    <option value="{{ available_taste.pk }}">{{ available_taste.name }}</option>
-                    {% endfor %}
-                </select>
+        <label>Taste</label>
+        <select unicorn:model="flavors.{{ forloop.counter0 }}.taste_set" multiple>
+          {% for available_taste in available_tastes %}
+          <option value="{{ available_taste.pk }}">{{ available_taste.name }}</option>
+          {% endfor %}
+        </select>
 
-                <ul>
-                {% for taste in flavor.taste_set.all %}
-                    <li>{{ taste.name }}</li>
-                {% endfor %}
-                </ul>
-                <br />
+        <ul>
+          {% for taste in flavor.taste_set.all %}
+          <li>{{ taste.name }}</li>
+          {% endfor %}
+        </ul>
+        <br />
 
-                <button unicorn:click="save({{ forloop.counter0 }})">save(flavor_idx)</button>
-                <button unicorn:click="delete({{ flavor.pk }})">delete(flavor.pk)</button>
-            </div>
-            {% endfor %}
-        </div>
+        <button unicorn:click="save({{ forloop.counter0 }})">save(flavor_idx)</button>
+        <button unicorn:click="delete({{ flavor.pk }})">delete(flavor.pk)</button>
+        <button u:click="model_typehint({{ flavor.pk }})">model_typehint(flavor.pk)</button>
+      </div>
+      {% endfor %}
     </div>
+  </div>
 </div>

--- a/tests/call_method_parser/test_parse_call_method_name.py
+++ b/tests/call_method_parser/test_parse_call_method_name.py
@@ -1,29 +1,36 @@
+import pytest
+
 from django_unicorn.call_method_parser import parse_call_method_name
 
 
+def setup_function():
+    """Clears lru_cache before every test in the module."""
+    parse_call_method_name.cache_clear()
+
+
 def test_single_int_arg():
-    expected = ("set_name", [1], {})
+    expected = ("set_name", (1,), {})
     actual = parse_call_method_name("set_name(1)")
 
     assert actual == expected
 
 
 def test_single_dict_arg():
-    expected = ("set_name", [{"1": 2, "3": 4}], {})
+    expected = ("set_name", ({"1": 2, "3": 4},), {})
     actual = parse_call_method_name('set_name({"1": 2, "3": 4})')
 
     assert actual == expected
 
 
 def test_multiple_args():
-    expected = ("set_name", [0, {"1": 2}], {})
+    expected = ("set_name", (0, {"1": 2}), {})
     actual = parse_call_method_name('set_name(0, {"1": 2})')
 
     assert actual == expected
 
 
 def test_multiple_args_2():
-    expected = ("set_name", [1, 2], {})
+    expected = ("set_name", (1, 2), {})
     actual = parse_call_method_name("set_name(1, 2)")
 
     assert actual == expected
@@ -32,9 +39,9 @@ def test_multiple_args_2():
 def test_var_with_curly_braces():
     expected = (
         "set_name",
-        [
+        (
             "{}",
-        ],
+        ),
         {},
     )
     actual = parse_call_method_name('set_name("{}")')
@@ -45,9 +52,9 @@ def test_var_with_curly_braces():
 def test_one_arg():
     expected = (
         "set_name",
-        [
+        (
             "1",
-        ],
+        ),
         {},
     )
     actual = parse_call_method_name('set_name("1")')
@@ -56,28 +63,28 @@ def test_one_arg():
 
 
 def test_kwargs():
-    expected = ("set_name", [], {"kwarg1": "wow"})
+    expected = ("set_name", tuple(), {"kwarg1": "wow"})
     actual = parse_call_method_name("set_name(kwarg1='wow')")
 
     assert actual == expected
 
 
 def test_args_and_kwargs():
-    expected = ("set_name", [8, 9], {"kwarg1": "wow"})
+    expected = ("set_name", (8, 9), {"kwarg1": "wow"})
     actual = parse_call_method_name("set_name(8, 9, kwarg1='wow')")
 
     assert actual == expected
 
 
 def test_special_method_without_parens():
-    expected = ("$reset", [], {})
+    expected = ("$reset", tuple(), {})
     actual = parse_call_method_name("$reset")
 
     assert actual == expected
 
 
 def test_special_method_with_parens():
-    expected = ("$reset", [], {})
+    expected = ("$reset", tuple(), {})
     actual = parse_call_method_name("$reset()")
 
     assert actual == expected

--- a/tests/call_method_parser/test_parse_call_method_name.py
+++ b/tests/call_method_parser/test_parse_call_method_name.py
@@ -39,9 +39,7 @@ def test_multiple_args_2():
 def test_var_with_curly_braces():
     expected = (
         "set_name",
-        (
-            "{}",
-        ),
+        ("{}",),
         {},
     )
     actual = parse_call_method_name('set_name("{}")')
@@ -52,9 +50,7 @@ def test_var_with_curly_braces():
 def test_one_arg():
     expected = (
         "set_name",
-        (
-            "1",
-        ),
+        ("1",),
         {},
     )
     actual = parse_call_method_name('set_name("1")')

--- a/tests/views/action_parsers/call_method/test_call_method_name.py
+++ b/tests/views/action_parsers/call_method/test_call_method_name.py
@@ -57,8 +57,9 @@ def test_call_method_name_with_kwarg():
     expected = 3
 
     component = FakeComponent(component_name="test", component_id="asdf")
-    actual = _call_method_name(component, "save_with_kwarg", args=tuple(),
-                               kwargs=MappingProxyType({"id": 2}))
+    actual = _call_method_name(
+        component, "save_with_kwarg", args=tuple(), kwargs=MappingProxyType({"id": 2})
+    )
 
     assert actual == expected
 
@@ -77,13 +78,51 @@ def test_call_method_name_arg_with_model_type_annotation():
 
 
 @pytest.mark.django_db
+def test_call_method_name_arg_with_model_type_annotation_multiple():
+    flavor_one = Flavor()
+    flavor_one.save()
+
+    flavor_two = Flavor()
+    flavor_two.save()
+
+    assert flavor_one.pk != flavor_two.pk
+
+    component = FakeComponent(component_name="test", component_id="asdf")
+    actual = _call_method_name(
+        component, "save_with_model", args=(flavor_one.pk,), kwargs={}
+    )
+    assert actual == flavor_one.pk
+
+    # second call
+    actual = _call_method_name(
+        component, "save_with_model", args=(flavor_two.pk,), kwargs={}
+    )
+    assert actual == flavor_two.pk
+
+    # third call
+    actual = _call_method_name(
+        component, "save_with_model", args=(flavor_one.pk,), kwargs={}
+    )
+    assert actual == flavor_one.pk
+
+    # fourth call
+    actual = _call_method_name(
+        component, "save_with_model", args=(flavor_one.pk,), kwargs={}
+    )
+    assert actual == flavor_one.pk
+
+
+@pytest.mark.django_db
 def test_call_method_name_kwarg_with_model_type_annotation():
     flavor = Flavor()
     flavor.save()
 
     component = FakeComponent(component_name="test", component_id="asdf")
     actual = _call_method_name(
-        component, "save_with_model", args=tuple(), kwargs=MappingProxyType({"pk": flavor.pk})
+        component,
+        "save_with_model",
+        args=tuple(),
+        kwargs=MappingProxyType({"pk": flavor.pk}),
     )
 
     assert actual == flavor.pk
@@ -91,8 +130,9 @@ def test_call_method_name_kwarg_with_model_type_annotation():
 
 def test_call_method_name_with_kwarg_with_union_and_int():
     component = FakeComponent(component_name="test", component_id="asdf")
-    actual = _call_method_name(component, "save_with_union", args=tuple(),
-                               kwargs=MappingProxyType({"id": 2}))
+    actual = _call_method_name(
+        component, "save_with_union", args=tuple(), kwargs=MappingProxyType({"id": 2})
+    )
 
     assert isinstance(actual, int)
 

--- a/tests/views/action_parsers/call_method/test_call_method_name.py
+++ b/tests/views/action_parsers/call_method/test_call_method_name.py
@@ -1,3 +1,4 @@
+from types import MappingProxyType
 from typing import Union
 
 import pytest
@@ -29,7 +30,7 @@ class FakeComponent(UnicornView):
 
 def test_call_method_name_missing():
     component = FakeComponent(component_name="test", component_id="asdf")
-    actual = _call_method_name(component, "save_missing", args=[], kwargs={})
+    actual = _call_method_name(component, "save_missing", args=tuple(), kwargs={})
 
     assert actual is None
 
@@ -38,7 +39,7 @@ def test_call_method_name_no_params():
     expected = 1
 
     component = FakeComponent(component_name="test", component_id="asdf")
-    actual = _call_method_name(component, "save", args=[], kwargs={})
+    actual = _call_method_name(component, "save", args=tuple(), kwargs={})
 
     assert actual == expected
 
@@ -47,7 +48,7 @@ def test_call_method_name_with_arg():
     expected = 2
 
     component = FakeComponent(component_name="test", component_id="asdf")
-    actual = _call_method_name(component, "save_with_arg", args=[1], kwargs={})
+    actual = _call_method_name(component, "save_with_arg", args=(1,), kwargs={})
 
     assert actual == expected
 
@@ -56,7 +57,8 @@ def test_call_method_name_with_kwarg():
     expected = 3
 
     component = FakeComponent(component_name="test", component_id="asdf")
-    actual = _call_method_name(component, "save_with_kwarg", args=[], kwargs={"id": 2})
+    actual = _call_method_name(component, "save_with_kwarg", args=tuple(),
+                               kwargs=MappingProxyType({"id": 2}))
 
     assert actual == expected
 
@@ -68,7 +70,7 @@ def test_call_method_name_arg_with_model_type_annotation():
 
     component = FakeComponent(component_name="test", component_id="asdf")
     actual = _call_method_name(
-        component, "save_with_model", args=[flavor.pk], kwargs={}
+        component, "save_with_model", args=(flavor.pk,), kwargs={}
     )
 
     assert actual == flavor.pk
@@ -81,7 +83,7 @@ def test_call_method_name_kwarg_with_model_type_annotation():
 
     component = FakeComponent(component_name="test", component_id="asdf")
     actual = _call_method_name(
-        component, "save_with_model", args=[], kwargs={"pk": flavor.pk}
+        component, "save_with_model", args=tuple(), kwargs=MappingProxyType({"pk": flavor.pk})
     )
 
     assert actual == flavor.pk
@@ -89,7 +91,8 @@ def test_call_method_name_kwarg_with_model_type_annotation():
 
 def test_call_method_name_with_kwarg_with_union_and_int():
     component = FakeComponent(component_name="test", component_id="asdf")
-    actual = _call_method_name(component, "save_with_union", args=[], kwargs={"id": 2})
+    actual = _call_method_name(component, "save_with_union", args=tuple(),
+                               kwargs=MappingProxyType({"id": 2}))
 
     assert isinstance(actual, int)
 
@@ -97,7 +100,7 @@ def test_call_method_name_with_kwarg_with_union_and_int():
 def test_call_method_name_with_kwarg_with_union_and_str():
     component = FakeComponent(component_name="test", component_id="asdf")
     actual = _call_method_name(
-        component, "save_with_union", args=[], kwargs={"id": "2"}
+        component, "save_with_union", args=tuple(), kwargs=MappingProxyType({"id": "2"})
     )
 
     assert isinstance(actual, str)


### PR DESCRIPTION
I was experiencing a problem with Unicorn, so here are some fixes.

Given: a component view method with single argument, type-hinted as a Model.

Problem: consecutive calls to the method with the same arguments would result in successful first call, but exceptions in next calls. Behavior repeats with restart of a worker.

It would seem that `parse_call_method_name()` output in the `lru_cache` would later be mutated, resulting in incorrect caching.

P.S. And a few other fixes - I noticed some small problems on the way.