### PR TITLE
Caching with parent/children multiple levels

### DIFF
--- a/django_unicorn/components/unicorn_view.py
+++ b/django_unicorn/components/unicorn_view.py
@@ -25,7 +25,7 @@ from ..errors import (
     UnicornCacheError,
 )
 from ..settings import get_setting
-from ..utils import is_non_string_sequence, restore_from_cache, cache_full_tree
+from ..utils import cache_full_tree, is_non_string_sequence, restore_from_cache
 from .fields import UnicornField
 from .unicorn_template_response import UnicornTemplateResponse
 
@@ -208,6 +208,7 @@ class UnicornView(TemplateView):
 
         if "parent" in kwargs:
             self.parent = kwargs["parent"]
+
             if self.parent and self not in self.parent.children:
                 self.parent.children.append(self)
 
@@ -394,6 +395,7 @@ class UnicornView(TemplateView):
         try:
             if COMPONENTS_MODULE_CACHE_ENABLED:
                 constructed_views_cache[self.component_id] = self
+
             cache_full_tree(self)
         except UnicornCacheError as e:
             logger.warning(e)
@@ -797,10 +799,12 @@ class UnicornView(TemplateView):
 
         component_cache_key = f"unicorn:component:{component_id}"
         cached_component = restore_from_cache(component_cache_key)
+
         if not cached_component:
             # Note that `hydrate()` and `complete` don't need to be called here
             # because this path only happens for re-rendering from the view
             cached_component = constructed_views_cache.get(component_id)
+
             if cached_component:
                 cached_component.setup(request)
                 cached_component._validate_called = False

--- a/django_unicorn/utils.py
+++ b/django_unicorn/utils.py
@@ -8,6 +8,8 @@ from typing import Dict, List, Union
 from typing import get_type_hints as typing_get_type_hints
 
 from django.conf import settings
+from django.core.cache import caches
+from django.http import HttpRequest
 from django.utils.html import _json_script_escapes
 from django.utils.safestring import mark_safe
 
@@ -15,7 +17,7 @@ import shortuuid
 
 import django_unicorn
 from django_unicorn.errors import UnicornCacheError
-
+from django_unicorn.settings import get_cache_alias
 
 try:
     from cachetools.lru import LRUCache
@@ -72,10 +74,58 @@ def dicts_equal(dictionary_one: Dict, dictionary_two: Dict) -> bool:
     return is_valid
 
 
+class PointerUnicornView:
+    def __init__(self, component_cache_key):
+        self.component_cache_key = component_cache_key
+        self.parent = None
+        self.children = []
+
+
+def cache_full_tree(component: "django_unicorn.views.UnicornView"):
+    root = component
+    while root.parent:
+        root = root.parent
+    cache = caches[get_cache_alias()]
+    with CacheableComponent(root) as caching:
+        for component in caching.components():
+            cache.set(component.component_cache_key, component)
+
+
+def restore_from_cache(component_cache_key: str, request: HttpRequest = None) -> "django_unicorn.views.UnicornView":
+    """
+    Gets a cached unicorn view by key, restoring and getting cached parents and children and setting the request
+    """
+    cache = caches[get_cache_alias()]
+    cached_component = cache.get(component_cache_key)
+
+    if cached_component:
+        roots = {}
+        root: "django_unicorn.views.UnicornView" = cached_component
+        roots[root.component_cache_key] = root
+        while root.parent:
+            root = cache.get(root.parent.component_cache_key)
+            roots[root.component_cache_key] = root
+        to_traverse: List["django_unicorn.views.UnicornView"] = []
+        to_traverse.append(root)
+        while to_traverse:
+            current = to_traverse.pop()
+            current.setup(request)
+            current._validate_called = False
+            current.calls = []
+            for index, child in enumerate(current.children):
+                key = child.component_cache_key
+                child = roots.pop(key, None) or cache.get(key)
+                child.parent = current
+                current.children[index] = child
+                to_traverse.append(child)
+
+    return cached_component
+
+
 class CacheableComponent:
     """
-    Updates a component into something that is cacheable/pickleable. Use in a `with` statement
-    or explicitly call `__enter__` `__exit__` to use. It will restore the original component
+    Updates a component into something that is cacheable/pickleable. Also set pointers to parents/children.
+    Use in a `with` statement or explicitly call `__enter__` `__exit__` to use. It will restore the original component
     on exit.
     """
 
@@ -97,13 +147,15 @@ class CacheableComponent:
                 extra_context = None
             request = component.request
             component.request = None
-            self._state[component.component_id] = (component, request, extra_context)
+            self._state[component.component_id] = (component, request, extra_context, component.parent, component.children.copy())
             if component.parent:
                 components.append(component.parent)
-            for child in component.children:
+                component.parent = PointerUnicornView(component.parent.component_cache_key)
+            for index, child in enumerate(component.children):
                 components.append(child)
+                component.children[index] = PointerUnicornView(child.component_cache_key)
 
-        for component, _, _ in self._state.values():
+        for component, *_ in self._state.values():
             try:
                 pickle.dumps(component)
             except (
@@ -116,11 +168,18 @@ class CacheableComponent:
                     f"Cannot cache component '{type(component)}' because it is not picklable: {type(e)}: {e}"
                 ) from e
 
+        return self
+
     def __exit__(self, *args):
-        for component, request, extra_context in self._state.values():
+        for component, request, extra_context, parent, children in self._state.values():
             component.request = request
+            component.parent = parent
+            component.children = children
             if extra_context:
                 component.extra_context = extra_context
+
+    def components(self) -> List["django_unicorn.views.UnicornView"]:
+        return [component for component, *_ in self._state.values()]
 
 
 def get_type_hints(obj) -> Dict:


### PR DESCRIPTION
When caching, switch children and parents to dummy references. Switch back when un-caching. Simplify setting parent/child releationships.