### PR TITLE
Modified form validation

### DIFF
--- a/django_unicorn/components/unicorn_view.py
+++ b/django_unicorn/components/unicorn_view.py
@@ -531,24 +531,15 @@ class UnicornView(TemplateView):
             # that is valid. Validating the valid one should not show an error for
             # the invalid one. Only after the invalid field is updated, should the
             # error show up and persist, even after updating the valid form.
-            if self.errors:
-                keys_to_remove = []
 
-                for key, value in self.errors.items():
-                    if key in form_errors:
-                        self.errors[key] = value
+            self.errors = dict()
+            if form_errors:
+                for key in form_errors:
+                    if key != "__all__":
+                        self.errors[key] = form_errors[key]
                     else:
-                        keys_to_remove.append(key)
+                        self.errors['all'] = form_errors[key]
 
-                for key in keys_to_remove:
-                    self.errors.pop(key)
-
-            if model_names is not None:
-                for key, value in form_errors.items():
-                    if key in model_names:
-                        self.errors[key] = value
-            else:
-                self.errors.update(form_errors)
 
         return self.errors
 


### PR DESCRIPTION
Hi, I was trying to use unicorn form validation with a model that has the `unique_together` model's Meta option. 
Unicorn validation didn't validate this option. I saw your validation code and i noted two things:

1. In the validation of a model with `unique_together` option or other types of validations that work on more than one fields of model error messages are indexed by Django with key called `__all__` and with existing validation this field was never read
2. I saw that you validate only the field that has been modified by the user and not the entire form like Django does with his forms

I fixed this two problems with the code that i modified in this pull request. I tried to run your tests and they didn't pass, i saw that this happens because the tests didn't enter in old code but now the tests enter and they don't pass. I haven't changed the tests.

Probably you need to change the documentation  and tests if you merge this pull request 