### PR TITLE
Remove use of collections.abc.ByteString

### DIFF
--- a/django_unicorn/utils.py
+++ b/django_unicorn/utils.py
@@ -280,7 +280,7 @@ def is_non_string_sequence(obj):
     if (
         isinstance(obj, collections.abc.Sequence)
         or isinstance(obj, collections.abc.Set)
-    ) and not isinstance(obj, (str, collections.abc.ByteString)):
+    ) and not isinstance(obj, (str, bytes, bytearray)):
         return True
 
     return False


### PR DESCRIPTION
This is an ABC that never really made much sense and was deprecated in https://github.com/python/cpython/issues/91896