### PR TITLE
Loading target multiple action elements with wildcard

### DIFF
--- a/django_unicorn/static/unicorn/js/eventListeners.js
+++ b/django_unicorn/static/unicorn/js/eventListeners.js
@@ -16,7 +16,7 @@ function handleLoading(component, targetElement) {
       if (loadingElement.target.includes("*")) {
         const targetRegex = toRegExp(loadingElement.target);
         const targetedElArray = [];
-        const childrenCollection = component.root.children;
+        const childrenCollection = component.root.getElementsByTagName("*");
         [...childrenCollection].forEach((child) => {
           [...child.attributes].forEach((attr) => {
             if (

--- a/django_unicorn/static/unicorn/js/utils.js
+++ b/django_unicorn/static/unicorn/js/utils.js
@@ -198,3 +198,23 @@ export function args(func) {
 
   return functionArgs;
 }
+
+/**
+ * Converts string with '*' wildcards to RegExp.
+ */
+export function toRegExp(str) {
+  const strArray = str.split("*");
+  let regexp = "";
+  strArray.forEach((item, idx) => {
+    if (idx === 0 && item === "") {
+      regexp = regexp.concat("[a-zA-Z0-9_:.\\-]*");
+    } else if (idx === strArray.length - 1) {
+      if (item !== "") {
+        regexp = regexp.concat(`(${item})`);
+      }
+    } else {
+      regexp = regexp.concat(`(${item})`, "[a-zA-Z0-9_:.\\-]*");
+    }
+  });
+  return new RegExp(regexp);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "django-unicorn",
-    "version": "0.48.0",
+    "version": "0.51.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "django-unicorn",
-            "version": "0.48.0",
+            "version": "0.51.0",
             "devDependencies": {
                 "@babel/core": "^7.11.6",
                 "@babel/preset-env": "^7.11.5",

--- a/tests/js/element/action.test.js
+++ b/tests/js/element/action.test.js
@@ -473,3 +473,79 @@ test("event action loading by key", (t) => {
   el.click();
   t.false(loadingEl.el.hidden);
 });
+
+test("event action wildcard loading by id", (t) => {
+  const html = `
+<div unicorn:id="5jypjiyb" unicorn:name="text-inputs" unicorn:checksum="GXzew3Km">
+  <button unicorn:click='test()' id='testId-1' u:key='testKey'></button>
+  <button unicorn:click='test()' id='testId-2' u:key='testKey'></button>
+  <button unicorn:click='test()' id='testId' u:key='testKey'></button>
+  <div u:loading u:target='testId-*'>
+  Loading
+  </div>
+</div>`;
+  const component = getComponent(html);
+
+  t.is(component.attachedEventTypes.length, 1);
+  t.is(component.actionEvents.click.length, 3);
+  t.is(component.loadingEls.length, 1);
+
+  const el1 = component.actionEvents.click[0].element.el;
+  const el2 = component.actionEvents.click[1].element.el;
+  const el3 = component.actionEvents.click[2].element.el;
+  const loadingEl = component.loadingEls[0];
+  t.true(loadingEl.el.hidden);
+
+  el1.click();
+  t.false(loadingEl.el.hidden);
+
+  loadingEl.el.hidden = true;
+  t.true(loadingEl.el.hidden);
+
+  el2.click();
+  t.false(loadingEl.el.hidden);
+
+  loadingEl.el.hidden = true;
+  t.true(loadingEl.el.hidden);
+
+  el3.click();
+  t.true(loadingEl.el.hidden);
+});
+
+test("event action wildcard loading by key", (t) => {
+  const html = `
+<div unicorn:id="5jypjiyb" unicorn:name="text-inputs" unicorn:checksum="GXzew3Km">
+  <button unicorn:click='test()' id='testId' u:key='testKey-1'></button>
+  <button unicorn:click='test()' id='testId' u:key='testKey-2'></button>
+  <button unicorn:click='test()' id='testId' u:key='testKey3'></button>
+  <div u:loading u:target='testKey-*'>
+  Loading
+  </div>
+</div>`;
+  const component = getComponent(html);
+
+  t.is(component.attachedEventTypes.length, 1);
+  t.is(component.actionEvents.click.length, 3);
+  t.is(component.loadingEls.length, 1);
+
+  const el1 = component.actionEvents.click[0].element.el;
+  const el2 = component.actionEvents.click[1].element.el;
+  const el3 = component.actionEvents.click[2].element.el;
+  const loadingEl = component.loadingEls[0];
+  t.true(loadingEl.el.hidden);
+
+  el1.click();
+  t.false(loadingEl.el.hidden);
+
+  loadingEl.el.hidden = true;
+  t.true(loadingEl.el.hidden);
+
+  el2.click();
+  t.false(loadingEl.el.hidden);
+
+  loadingEl.el.hidden = true;
+  t.true(loadingEl.el.hidden);
+
+  el3.click();
+  t.true(loadingEl.el.hidden);
+});

--- a/tests/js/element/action.test.js
+++ b/tests/js/element/action.test.js
@@ -478,7 +478,9 @@ test("event action wildcard loading by id", (t) => {
   const html = `
 <div unicorn:id="5jypjiyb" unicorn:name="text-inputs" unicorn:checksum="GXzew3Km">
   <button unicorn:click='test()' id='testId-1' u:key='testKey'></button>
-  <button unicorn:click='test()' id='testId-2' u:key='testKey'></button>
+  <div>
+    <button unicorn:click='test()' id='testId-2' u:key='testKey'></button>
+  </div>
   <button unicorn:click='test()' id='testId' u:key='testKey'></button>
   <div u:loading u:target='testId-*'>
   Loading
@@ -516,7 +518,9 @@ test("event action wildcard loading by key", (t) => {
   const html = `
 <div unicorn:id="5jypjiyb" unicorn:name="text-inputs" unicorn:checksum="GXzew3Km">
   <button unicorn:click='test()' id='testId' u:key='testKey-1'></button>
-  <button unicorn:click='test()' id='testId' u:key='testKey-2'></button>
+  <div>
+    <button unicorn:click='test()' id='testId' u:key='testKey-2'></button>
+  </div>
   <button unicorn:click='test()' id='testId' u:key='testKey3'></button>
   <div u:loading u:target='testKey-*'>
   Loading

--- a/tests/js/utils/toRegExp.test.js
+++ b/tests/js/utils/toRegExp.test.js
@@ -1,0 +1,21 @@
+import test from "ava";
+import { toRegExp } from "../../../django_unicorn/static/unicorn/js/utils";
+
+test("To regexp 'test-*'", (t) => {
+  t.deepEqual(toRegExp("test-*"), /(test-)[a-zA-Z0-9_:.\-]*/);
+});
+
+test("To regexp '*-test'", (t) => {
+  t.deepEqual(toRegExp("*-test"), /[a-zA-Z0-9_:.\-]*(-test)/);
+});
+
+test("To regexp 'test-*-final'", (t) => {
+  t.deepEqual(toRegExp("test-*-final"), /(test-)[a-zA-Z0-9_:.\-]*(-final)/);
+});
+
+test("To regexp 'test-*-v*-final'", (t) => {
+  t.deepEqual(
+    toRegExp("test-*-v*-final"),
+    /(test-)[a-zA-Z0-9_:.\-]*(-v)[a-zA-Z0-9_:.\-]*(-final)/
+  );
+});


### PR DESCRIPTION
Hi Adam,

This PR addresses the feature request in #542. Users would be able to target multiple action elements using one or more asterisk wildcards e.g:
- `<div u:loading u:target="foo-*">`
- `<div u:loading u:target="foo-*-bar">`
- `<div u:loading u:target="*foo*bar">` 

I've added tests and manually tested it against my personal use case, which it satisfies.

Cheers,
Armand