### PR TITLE
Use `CSRF_COOKIE_NAME` from settings

### DIFF
--- a/django_unicorn/static/unicorn/js/component.js
+++ b/django_unicorn/static/unicorn/js/component.js
@@ -26,6 +26,7 @@ export class Component {
     this.key = args.key;
     this.messageUrl = args.messageUrl;
     this.csrfTokenHeaderName = args.csrfTokenHeaderName;
+    this.csrfTokenCookieName = args.csrfTokenCookieName;
     this.reloadScriptElements = args.reloadScriptElements;
     this.hash = args.hash;
     this.data = args.data || {};

--- a/django_unicorn/static/unicorn/js/unicorn.js
+++ b/django_unicorn/static/unicorn/js/unicorn.js
@@ -5,11 +5,12 @@ import { components, lifecycleEvents } from "./store.js";
 let messageUrl = "";
 let reloadScriptElements = false;
 let csrfTokenHeaderName = "X-CSRFToken";
+let csrfTokenCookieName = "csrftoken"
 
 /**
  * Initializes the Unicorn object.
  */
-export function init(_messageUrl, _csrfTokenHeaderName, _reloadScriptElements) {
+export function init(_messageUrl, _csrfTokenHeaderName, _csrfTokenCookieName, _reloadScriptElements) {
   messageUrl = _messageUrl;
   reloadScriptElements = _reloadScriptElements || false;
 
@@ -17,9 +18,14 @@ export function init(_messageUrl, _csrfTokenHeaderName, _reloadScriptElements) {
     csrfTokenHeaderName = _csrfTokenHeaderName;
   }
 
+  if (hasValue(_csrfTokenCookieName)) {
+    csrfTokenCookieName = _csrfTokenCookieName;
+  }
+
   return {
     messageUrl,
     csrfTokenHeaderName,
+    csrfTokenCookieName,
     reloadScriptElements,
   };
 }
@@ -30,6 +36,7 @@ export function init(_messageUrl, _csrfTokenHeaderName, _reloadScriptElements) {
 export function componentInit(args) {
   args.messageUrl = messageUrl;
   args.csrfTokenHeaderName = csrfTokenHeaderName;
+  args.csrfTokenCookieName = csrfTokenCookieName;
   args.reloadScriptElements = reloadScriptElements;
 
   const component = new Component(args);

--- a/django_unicorn/static/unicorn/js/utils.js
+++ b/django_unicorn/static/unicorn/js/utils.js
@@ -51,7 +51,7 @@ export function $(selector, scope) {
  */
 export function getCsrfToken(component) {
   // Default to looking for the CSRF in the cookie
-  const cookieKey = "csrftoken=";
+  const cookieKey = component.csrfTokenCookieName + "="
   const csrfTokenCookie = component.document.cookie
     .split(";")
     .filter((item) => item.trim().startsWith(cookieKey));

--- a/django_unicorn/templates/unicorn/scripts.html
+++ b/django_unicorn/templates/unicorn/scripts.html
@@ -11,7 +11,7 @@
     reloadScriptElements = true;
   }
 
-  Unicorn.init(url, "{{ CSRF_HEADER_NAME }}", reloadScriptElements);
+  Unicorn.init(url, "{{ CSRF_HEADER_NAME }}", "{{ CSRF_COOKIE_NAME }}", reloadScriptElements);
 </script>
 {% else %}
 <script type="module">
@@ -27,6 +27,6 @@
       reloadScriptElements = true;
     }
 
-    Unicorn.init(url, "{{ CSRF_HEADER_NAME }}", reloadScriptElements);
+    Unicorn.init(url, "{{ CSRF_HEADER_NAME }}", "{{ CSRF_COOKIE_NAME }}", reloadScriptElements);
 </script>
 {% endif %}

--- a/django_unicorn/templatetags/unicorn.py
+++ b/django_unicorn/templatetags/unicorn.py
@@ -25,9 +25,12 @@ def unicorn_scripts():
 
     csrf_header_name = csrf_header_name.replace("_", "-")
 
+    csrf_cookie_name = settings.CSRF_COOKIE_NAME
+
     return {
         "MINIFIED": get_setting("MINIFIED", not settings.DEBUG),
         "CSRF_HEADER_NAME": csrf_header_name,
+        "CSRF_COOKIE_NAME": csrf_cookie_name,
         "RELOAD_SCRIPT_ELEMENTS": get_setting("RELOAD_SCRIPT_ELEMENTS", False),
     }
 

--- a/tests/js/unicorn/init.test.js
+++ b/tests/js/unicorn/init.test.js
@@ -2,25 +2,28 @@ import test from "ava";
 import { init } from "../../../django_unicorn/static/unicorn/js/unicorn.js";
 
 test("init unicorn", (t) => {
-  const actual = init("unicorn/", "X-Unicorn");
+  const actual = init("unicorn/", "X-Unicorn", "unicorn");
 
   t.true(actual.messageUrl === "unicorn/");
   t.true(actual.csrfTokenHeaderName === "X-Unicorn");
+  t.true(actual.csrfTokenCookieName === "unicorn");
   t.false(actual.reloadScriptElements);
 });
 
 test("init unicorn with no reload", (t) => {
-  const actual = init("unicorn/", "X-Unicorn", false);
+  const actual = init("unicorn/", "X-Unicorn", "unicorn", false);
 
   t.true(actual.messageUrl === "unicorn/");
   t.true(actual.csrfTokenHeaderName === "X-Unicorn");
+  t.true(actual.csrfTokenCookieName === "unicorn");
   t.false(actual.reloadScriptElements);
 });
 
 test("init unicorn with reload", (t) => {
-  const actual = init("unicorn/", "X-Unicorn", true);
+  const actual = init("unicorn/", "X-Unicorn", "unicorn", true);
 
   t.true(actual.messageUrl === "unicorn/");
   t.true(actual.csrfTokenHeaderName === "X-Unicorn");
+  t.true(actual.csrfTokenCookieName === "unicorn");
   t.true(actual.reloadScriptElements);
 });

--- a/tests/templatetags/test_unicorn_scripts.py
+++ b/tests/templatetags/test_unicorn_scripts.py
@@ -5,6 +5,7 @@ def test_unicorn_scripts():
     actual = unicorn_scripts()
 
     assert actual["CSRF_HEADER_NAME"] == "X-CSRFTOKEN"
+    assert actual["CSRF_COOKIE_NAME"] == "csrftoken"
     assert actual["MINIFIED"] is True
 
 
@@ -13,6 +14,7 @@ def test_unicorn_scripts_debug(settings):
     actual = unicorn_scripts()
 
     assert actual["CSRF_HEADER_NAME"] == "X-CSRFTOKEN"
+    assert actual["CSRF_COOKIE_NAME"] == "csrftoken"
     assert actual["MINIFIED"] is False
 
 
@@ -21,6 +23,7 @@ def test_unicorn_scripts_minified_true(settings):
     actual = unicorn_scripts()
 
     assert actual["CSRF_HEADER_NAME"] == "X-CSRFTOKEN"
+    assert actual["CSRF_COOKIE_NAME"] == "csrftoken"
     assert actual["MINIFIED"] is True
 
 
@@ -36,3 +39,9 @@ def test_unicorn_scripts_csrf_header_name(settings):
     actual = unicorn_scripts()
 
     assert actual["CSRF_HEADER_NAME"] == "X-UNICORN"
+
+def test_unicorn_scripts_csrf_cookie_name(settings):
+    settings.CSRF_COOKIE_NAME = "unicorn-csrftoken"
+    actual = unicorn_scripts()
+
+    assert actual["CSRF_COOKIE_NAME"] == "unicorn-csrftoken"


### PR DESCRIPTION
Make unicorn use the `CSRF_COOKIE_NAME` from settings in a similar way to what already done for `CSRF_HEADER_NAME`.

Ref. https://github.com/adamghill/django-unicorn/issues/544