### PR TITLE
Pass "data" as a keyword argument when instantiating form_class

### DIFF
--- a/django_unicorn/components/unicorn_view.py
+++ b/django_unicorn/components/unicorn_view.py
@@ -468,7 +468,7 @@ class UnicornView(TemplateView):
     def _get_form(self, data):
         if hasattr(self, "form_class"):
             try:
-                form = self.form_class(data)
+                form = self.form_class(data=data)
                 form.is_valid()
 
                 return form


### PR DESCRIPTION
I ran into a problem using AuthenticationForm as form_class in UnicornView due to the extra `request` argument in the forms constructor. This caused form data to be passed incorrectly in _get_form and was fixed by simply changing "data" to a keyword argument.

My component:
```python
from django_unicorn.components import UnicornView
from django.contrib.auth.forms import AuthenticationForm

class AuthenticateView(UnicornView):
    form_class = AuthenticationForm
    
    username = ""
    password = ""
```
Cause the error:
```
'AuthenticationForm' object has no attribute 'cleaned_data'
```

While not necessarily condoning the use of authentication forms with unicorn, a temporary fix to a problem like this can be solved by inheriting the form class and changing `init`, like this:

```python

class AuthForm(AuthenticationForm):
    def __init__(self, *args, **kwargs):
        super().__init__(None, *args, **kwargs)

class AuthenticateView(UnicornView):
    form_class = AuthForm
    
    username = ""
    password = ""

```

Great work on Unicorn by the way