### PR TITLE
Handle component arguments

### DIFF
--- a/django_unicorn/call_method_parser.py
+++ b/django_unicorn/call_method_parser.py
@@ -67,7 +67,7 @@ def _get_expr_string(expr: ast.expr) -> str:
 @lru_cache(maxsize=128, typed=True)
 def eval_value(value):
     """
-    Uses `ast.literal_eval` to parse strings into an appropriate Python primative.
+    Uses `ast.literal_eval` to parse strings into an appropriate Python primitive.
 
     Also returns an appropriate object for strings that look like they represent datetime,
     date, time, duration, or UUID.

--- a/docs/source/advanced.md
+++ b/docs/source/advanced.md
@@ -16,21 +16,56 @@ class HelloWorldView(UnicornView):
 
 ## Instance properties
 
+### component_args
+
+The arguments passed into the component.
+
+```html
+<!-- index.html -->
+{% unicorn 'hello-arg' 'World' %}
+```
+
+```python
+# hello_arg.py
+from django_unicorn.components import UnicornView
+
+class HelloArgView(UnicornView):
+    def mount(self):
+      assert self.component_args[0] == "World"
+```
+
+### component_kwargs
+
+The keyword arguments passed into the component.
+
+```html
+<!-- index.html -->
+{% unicorn 'hello-kwarg' hello='World' %}
+```
+
+```python
+# hello_kwarg.py
+from django_unicorn.components import UnicornView
+
+class HelloKwargView(UnicornView):
+    def mount(self):
+      assert self.component_kwargs["hello"] == "World"
+```
+
 ### request
 
-The current `request` is available on `self` in the component's methods.
+The current `request`.
 
 ```python
 # hello_world.py
 from django_unicorn.components import UnicornView
 
 class HelloWorldView(UnicornView):
-    def __init__(self, *args, **kwargs):
-        super.__init__(**kwargs)
+    def mount(self):
         print("Initial request that rendered the component", self.request)
 
     def test(self):
-        print("callMethod request to re-render the component", self.request)
+        print("AJAX request that re-renders the component", self.request)
 ```
 
 ## Custom methods
@@ -75,22 +110,6 @@ class StateView(UnicornView):
 :::
 
 ## Instance methods
-
-### \_\_init\_\_()
-
-Gets called when the component gets constructed for the very first time. Note that constructed components get cached to reduce the amount of time discovering and instantiating them, so `__init__` only gets called the very first time the component gets rendered.
-
-```python
-# hello_world.py
-from django_unicorn.components import UnicornView
-
-class HelloWorldView(UnicornView):
-    name = "original"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(**kwargs)
-        self.name = "initialized"
-```
 
 ### mount()
 

--- a/tests/templates/test_component_args.html
+++ b/tests/templates/test_component_args.html
@@ -1,0 +1,3 @@
+<div>
+  <b>{{ hello }}</b>
+</div>

--- a/tests/templatetags/test_unicorn_render.py
+++ b/tests/templatetags/test_unicorn_render.py
@@ -45,31 +45,36 @@ class FakeComponentChildImplicit(UnicornView):
         return self.parent is not None
 
 
+class FakeComponentArgs(UnicornView):
+    template_name = "templates/test_component_args.html"
+    hello = "world"
+
+    def mount(self):
+        self.hello = self.component_args[0]
+
+
 class FakeComponentKwargs(UnicornView):
     template_name = "templates/test_component_kwargs.html"
     hello = "world"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(**kwargs)
-        self.hello = kwargs.get("test_kwarg")
+    def mount(self):
+        self.hello = self.component_kwargs.get("test_kwarg")
 
 
 class FakeComponentKwargsWithHtmlEntity(UnicornView):
     template_name = "templates/test_component_kwargs_with_html_entity.html"
     hello = "world"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(**kwargs)
-        self.hello = kwargs.get("test_kwarg")
+    def mount(self):
+        self.hello = self.component_kwargs.get("test_kwarg")
 
 
 class FakeComponentModel(UnicornView):
     template_name = "templates/test_component_model.html"
     model_id = None
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(**kwargs)
-        self.model_id = kwargs.get("model_id")
+    def mount(self):
+        self.model_id = self.component_kwargs.get("model_id")
 
 
 class FakeComponentCalls(UnicornView):
@@ -156,6 +161,18 @@ def test_unicorn_template_renders_with_implicit_parent_and_child(client):
     assert "==child==" in content
     assert "has_parent:True" in content
     assert '<script type="application/json" id="unicorn:data:' in content
+
+
+def test_unicorn_render_arg():
+    token = Token(
+        TokenType.TEXT,
+        "unicorn 'tests.templatetags.test_unicorn_render.FakeComponentArgs' 'tested!'",
+    )
+    unicorn_node = unicorn(Parser([]), token)
+    context = {}
+    actual = unicorn_node.render(Context(context))
+
+    assert "<b>tested!</b>" in actual
 
 
 def test_unicorn_render_kwarg():


### PR DESCRIPTION
Kwargs were able to be passed into components, but not arguments. This adds that capability and also exposes `component_args` and `component_kwargs` as instance methods on the component.