### PR TITLE
Use type hints in action args/kwargs

### DIFF
--- a/django_unicorn/static/unicorn/js/messageSender.js
+++ b/django_unicorn/static/unicorn/js/messageSender.js
@@ -46,6 +46,7 @@ export function send(component, callback) {
     body: JSON.stringify(body),
   })
     .then((response) => {
+      console.log("responseJson");
       if (response.ok) {
         return response.json();
       }
@@ -77,6 +78,8 @@ export function send(component, callback) {
       if (!responseJson) {
         return;
       }
+
+      console.log("responseJson", responseJson);
 
       if (responseJson.queued && responseJson.queued === true) {
         return;

--- a/django_unicorn/utils.py
+++ b/django_unicorn/utils.py
@@ -284,3 +284,16 @@ def is_non_string_sequence(obj):
         return True
 
     return False
+
+
+def is_int(s: str) -> bool:
+    """
+    Checks whether a string is actually an integer.
+    """
+
+    try:
+        int(s)
+    except ValueError:
+        return False
+    else:
+        return True

--- a/django_unicorn/views/__init__.py
+++ b/django_unicorn/views/__init__.py
@@ -94,7 +94,7 @@ def _process_component_request(
     original_data = copy.deepcopy(component_request.data)
 
     # Set component properties based on request data
-    for (property_name, property_value) in component_request.data.items():
+    for property_name, property_value in component_request.data.items():
         set_property_from_data(component, property_name, property_value)
     component.hydrate()
 
@@ -251,6 +251,10 @@ def _process_component_request(
                         partial_doms.append({"id": target, "dom": str(element)})
                         partial_found = True
                         break
+
+    component_request.data = {
+        key: component_request.data[key] for key in sorted(component_request.data)
+    }
 
     res = {
         "id": component_request.id,

--- a/django_unicorn/views/action_parsers/call_method.py
+++ b/django_unicorn/views/action_parsers/call_method.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, Tuple
+from datetime import date, datetime
+from typing import Any, Dict, Tuple, Union
 
 from django.db.models import Model
 
 from django_unicorn.call_method_parser import (
+    CASTERS,
     InvalidKwarg,
     parse_call_method_name,
     parse_kwarg,
@@ -13,6 +15,19 @@ from django_unicorn.utils import get_method_arguments, get_type_hints
 from django_unicorn.views.action_parsers.utils import set_property_value
 from django_unicorn.views.objects import ComponentRequest, Return
 from django_unicorn.views.utils import set_property_from_data
+
+
+try:
+    from typing import get_args, get_origin
+except ImportError:
+    # Fallback to dunder methods for older versions of Python
+    def get_args(type_hint):
+        if hasattr(type_hint, "__args__"):
+            return type_hint.__args__
+
+    def get_origin(type_hint):
+        if hasattr(type_hint, "__origin__"):
+            return type_hint.__origin__
 
 
 def handle(component_request: ComponentRequest, component: UnicornView, payload: Dict):
@@ -92,6 +107,51 @@ def handle(component_request: ComponentRequest, component: UnicornView, payload:
     )
 
 
+def _cast_value(type_hint, value):
+    """
+    Try to cast the value based on the type hint and
+    `django_unicorn.call_method_parser.CASTERS`.
+
+    Additional features:
+    - convert `int`/`float` epoch to `datetime` or `date`
+    - instantiate the `type_hint` class with passed-in value
+    """
+
+    type_hints = []
+
+    if get_origin(type_hint) is Union:
+        for arg in get_args(type_hint):
+            type_hints.append(arg)
+    else:
+        type_hints.append(type_hint)
+
+    for type_hint in type_hints:
+        caster = CASTERS.get(type_hint)
+
+        if caster:
+            try:
+                value = caster(value)
+                break
+            except TypeError:
+                if (type_hint is datetime or type_hint is date) and (
+                    isinstance(value, int) or isinstance(value, float)
+                ):
+                    try:
+                        value = datetime.fromtimestamp(value)
+
+                        if type_hint is date:
+                            value = value.date()
+
+                        break
+                    except ValueError:
+                        pass
+        else:
+            value = type_hint(value)
+            break
+
+    return value
+
+
 @timed
 def _call_method_name(
     component: UnicornView, method_name: str, args: Tuple[Any], kwargs: Dict[str, Any]
@@ -109,35 +169,56 @@ def _call_method_name(
     if method_name is not None and hasattr(component, method_name):
         func = getattr(component, method_name)
 
-        if len(args) == 1 or len(kwargs) == 1:
-            arguments = get_method_arguments(func)
-            type_hints = get_type_hints(func)
+        parsed_args = []
+        parsed_kwargs = {}
+        arguments = get_method_arguments(func)
+        type_hints = get_type_hints(func)
 
-            for argument in arguments:
-                if argument in type_hints:
-                    type_hint = type_hints[argument]
+        for argument in arguments:
+            if argument in type_hints:
+                type_hint = type_hints[argument]
 
-                    if isinstance(type_hint, type) and issubclass(type_hint, Model):
-                        DbModel = type_hint
-                        key = "pk"
-                        value = None
+                # Check that the type hint is a regular class or Union
+                # (which will also include Optional)
+                # TODO: Use types.UnionType to handle `|` for newer unions
+                if (
+                    not isinstance(type_hint, type)
+                    and get_origin(type_hint) is not Union
+                ):
+                    continue
 
-                        if args:
-                            value = args[0]
-                        elif kwargs:
-                            kwargs = kwargs.copy()  # no mutation of original
-                            (key, value) = list(kwargs.items())[0]
-                            del kwargs[key]
+                is_model = False
 
-                        model = DbModel.objects.get(**{key: value})
-                        args = [model]
+                try:
+                    is_model = issubclass(type_hint, Model)
+                except TypeError:
+                    pass
 
-        if args and kwargs:
-            return func(*args, **kwargs)
-        elif args:
-            return func(*args, **kwargs)
-        elif kwargs:
-            return func(**kwargs)
+                if is_model:
+                    DbModel = type_hint
+                    key = "pk"
+                    value = None
+
+                    if not kwargs:
+                        value = args[len(parsed_args)]
+                        parsed_args.append(DbModel.objects.get(**{key: value}))
+                    else:
+                        value = kwargs.get("pk")
+                        parsed_kwargs[argument] = DbModel.objects.get(**{key: value})
+
+                elif argument in kwargs:
+                    parsed_kwargs[argument] = _cast_value(type_hint, kwargs[argument])
+                else:
+                    parsed_args.append(_cast_value(type_hint, args[len(parsed_args)]))
+            elif argument in kwargs:
+                parsed_kwargs[argument] = kwargs[argument]
+            else:
+                parsed_args.append(args[len(parsed_args)])
+
+        if parsed_args:
+            return func(*parsed_args, **parsed_kwargs)
+        elif parsed_kwargs:
+            return func(**parsed_kwargs)
         else:
             return func()
 
@@ -159,7 +240,7 @@ def _get_property_value(component: UnicornView, property_name: str) -> Any:
     property_name_parts = property_name.split(".")
     component_or_field = component
 
-    for (idx, property_name_part) in enumerate(property_name_parts):
+    for idx, property_name_part in enumerate(property_name_parts):
         if hasattr(component_or_field, property_name_part):
             if idx == len(property_name_parts) - 1:
                 return getattr(component_or_field, property_name_part)

--- a/django_unicorn/views/objects.py
+++ b/django_unicorn/views/objects.py
@@ -29,6 +29,30 @@ class Action:
         )
 
 
+def is_int(s):
+    try:
+        int(s)
+    except ValueError:
+        return False
+    else:
+        return True
+
+
+def sort_dict(d):
+    items = [
+        [k, v]
+        for k, v in sorted(
+            d.items(), key=lambda x: x[0] if not is_int(x[0]) else int(x[0])
+        )
+    ]
+
+    for item in items:
+        if isinstance(item[1], dict):
+            item[1] = sort_dict(item[1])
+
+    return dict(items)
+
+
 class ComponentRequest:
     """
     Parses, validates, and stores all of the data from the message request.

--- a/example/unicorn/components/objects.py
+++ b/example/unicorn/components/objects.py
@@ -50,6 +50,11 @@ class ObjectsView(UnicornView):
     def get_date(self):
         self.date_example = now()
 
+    def check_date(self, dt: datetime):
+        assert type(dt) is datetime
+
+        self.date_example = dt
+
     def set_dictionary(self, val):
         self.dictionary = val
 

--- a/example/unicorn/components/objects.py
+++ b/example/unicorn/components/objects.py
@@ -38,6 +38,7 @@ class ObjectsView(UnicornView):
     unicorn_field = BookField()
     pydantic_field = PydanticBook()
     dictionary = {"name": "dictionary", "nested": {"name": "nested dictionary"}}
+    dictionary_2 = {"5": "a", "9": "b"}
     book = Book(title="The Sandman")
     books = Book.objects.all()
     date_example = now()
@@ -51,6 +52,11 @@ class ObjectsView(UnicornView):
 
     def set_dictionary(self, val):
         self.dictionary = val
+
+    def set_dictionary_2(self):
+        self.dictionary_2["1"] = "c"
+        self.dictionary_2["6"] = "d"
+        self.dictionary_2["11"] = "e"
 
     def add_one_to_float(self):
         self.float_example += 1

--- a/example/unicorn/templates/unicorn/objects.html
+++ b/example/unicorn/templates/unicorn/objects.html
@@ -33,6 +33,20 @@
   </div>
 
   <div>
+    <label>Datetime</label>
+
+    <div>
+      {{ date_example }}
+    </div>
+    <div>
+      <button u:click='get_date'>get_date</button>
+      <button u:click='check_date("2020-09-12T01:01:01")'>check_date static</button>
+      <button u:click='check_date("{{ date_example|date:'c' }}")'>check_date (c)</button>
+      <button u:click='check_date({{ date_example|date:'U' }})'>check_date (U)</button>
+    </div>
+  </div>
+
+  <div>
     <label>Pydantic field</label>
     <input u:model="pydantic_field.title" type="text" id="pydanticField">
     <input u:model="pydantic_field.publish_date" type="text" id="datetimePydanticField">
@@ -112,6 +126,7 @@
 
   <div>
     <label>Enums</label>
+    <br />
 
     <button unicorn:click="set_color({{ color.value }})">Sets color based on `self.color` enum</button>
     <button unicorn:click="set_color(2)">Sets `self.color` to `Color.GREEN`</button>
@@ -121,6 +136,8 @@
     color: {{ color }}
   </div>
 
-  <button u:click="$reset">$reset</button>
-  <button u:click="$refresh">$refresh</button>
+  <div>
+    <button u:click="$reset">$reset</button>
+    <button u:click="$refresh">$refresh</button>
+  </div>
 </div>

--- a/example/unicorn/templates/unicorn/objects.html
+++ b/example/unicorn/templates/unicorn/objects.html
@@ -24,7 +24,12 @@
     dictionary.name: {{ dictionary.name }}<br />
     dictionary.nested.name: {{ dictionary.nested.name }}<br />
     <button u:click='set_dictionary({"name": 1, "nested": {"name": 2}})'>set dictionary(1)</button>
-    <button u:click='dictionary.nested.name=2'>set dictionary(2)</button>
+    <button u:click='dictionary.nested.name=3'>set dictionary(3)</button>
+    <button u:click='set_dictionary_2'>set dictionary whoa</button>
+
+    <div>
+      {{ dictionary_2 }}
+    </div>
   </div>
 
   <div>

--- a/tests/serializer/test_dumps.py
+++ b/tests/serializer/test_dumps.py
@@ -155,15 +155,15 @@ def test_complicated_model():
     )
 
     expected = {
-        "pk": 2,
-        "name": "abc",
-        "datetime": model.datetime.isoformat()[:-3],
-        "float_value": "0.583",
-        "decimal_value": "0.984",
-        "uuid": str(model.uuid),
         "date": str(model.date),
-        "time": str(model.time)[:-3],
+        "datetime": model.datetime.isoformat()[:-3],
+        "decimal_value": "0.984",
         "duration": "-1 19:00:00",
+        "float_value": "0.583",
+        "name": "abc",
+        "pk": 2,
+        "time": str(model.time)[:-3],
+        "uuid": str(model.uuid),
     }
 
     actual = serializer.dumps(model)
@@ -677,7 +677,7 @@ def test_nested_list_float():
 
 
 def test_nested_list_float_complicated():
-    expected = '{"name":{"blob":[1,2,"0.0"]},"more":["1.9",2,5],"another":[{"great":"1.0","ok":["1.6","0.0",4]}]}'
+    expected = '{"another":[{"great":"1.0","ok":["1.6","0.0",4]}],"more":["1.9",2,5],"name":{"blob":[1,2,"0.0"]}}'
     actual = serializer.dumps(
         {
             "name": {"blob": [1, 2, 0.0]},
@@ -707,7 +707,7 @@ def test_pydantic():
         title = "The Grapes of Wrath"
         author = "John Steinbeck"
 
-    expected = '{"title":"The Grapes of Wrath","author":"John Steinbeck"}'
+    expected = '{"author":"John Steinbeck","title":"The Grapes of Wrath"}'
     actual = serializer.dumps(Book())
 
     assert expected == actual
@@ -752,7 +752,7 @@ def test_exclude_field_attributes_nested():
 
 
 def test_exclude_field_attributes_invalid_field_attribute():
-    expected = '{"book":{"title":"The Grapes of Wrath","author":"John Steinbeck"}}'
+    expected = '{"book":{"author":"John Steinbeck","title":"The Grapes of Wrath"}}'
 
     actual = serializer.dumps(
         {"book": {"title": "The Grapes of Wrath", "author": "John Steinbeck"}},
@@ -763,7 +763,7 @@ def test_exclude_field_attributes_invalid_field_attribute():
 
 
 def test_exclude_field_attributes_empty_string():
-    expected = '{"book":{"title":"The Grapes of Wrath","author":"John Steinbeck"}}'
+    expected = '{"book":{"author":"John Steinbeck","title":"The Grapes of Wrath"}}'
 
     actual = serializer.dumps(
         {"book": {"title": "The Grapes of Wrath", "author": "John Steinbeck"}},
@@ -774,7 +774,7 @@ def test_exclude_field_attributes_empty_string():
 
 
 def test_exclude_field_attributes_none():
-    expected = '{"book":{"title":"The Grapes of Wrath","author":"John Steinbeck"}}'
+    expected = '{"book":{"author":"John Steinbeck","title":"The Grapes of Wrath"}}'
 
     actual = serializer.dumps(
         {"book": {"title": "The Grapes of Wrath", "author": "John Steinbeck"}},
@@ -816,3 +816,38 @@ def test_exclude_field_attributes_invalid_type():
             {"book": {"title": "The Grapes of Wrath", "author": "John Steinbeck"}},
             exclude_field_attributes=("book.blob"),
         )
+
+
+def test_dictionary_with_int_keys_as_strings():
+    # Browsers will sort a dictionary that has stringified integers as if they the keys
+    # were integers which messes up checksum calculation
+    expected = '{"1":"a","2":"b","4":"c","11":"d","24":"e"}'
+
+    actual = serializer.dumps(
+        {
+            "11": "d",
+            "4": "c",
+            "1": "a",
+            "24": "e",
+            "2": "b",
+        }
+    )
+
+    assert expected == actual
+
+
+def test_dictionary_with_int_keys_as_strings_no_sort():
+    expected = '{"11":"d","4":"c","1":"a","24":"e","2":"b"}'
+
+    actual = serializer.dumps(
+        {
+            "11": "d",
+            "4": "c",
+            "1": "a",
+            "24": "e",
+            "2": "b",
+        },
+        sort_dict=False,
+    )
+
+    assert expected == actual


### PR DESCRIPTION
When type annotations are used in args or kwargs in a method used for an action, `Unicorn` will attempt to coerce the argument into the type annotation. Solves for https://github.com/adamghill/django-unicorn/issues/514.

```python
# test_component.py
from django_unicorn.components import UnicornView
from datetime import datetime

class TestComponent(UnicornView):
    def check_datetime(self, _datetime: datetime):
        # the `datetime` type annotation tells Unicorn to convert `_datetime` into a `datetime` object
        assert isinstance(_datetime) is datetime
```

```html
<!-- test-component.html -->
<div>
  <button u:click='check_datetime("2020-09-12T01:01:01")'>check with a static string</button>
  <button u:click='check_datetime("{{ date_example|date:'c' }}")'>check with a dynamic string</button>
  <button u:click='check_datetime({{ date_example|date:'U' }})'>check with epoch (notice no quotes around the arg to check_datetime)</button>
</div>
```