### PR TITLE
Allow custom html tags to be valid

### DIFF
--- a/django_unicorn/components/unicorn_template_response.py
+++ b/django_unicorn/components/unicorn_template_response.py
@@ -50,7 +50,7 @@ def is_html_well_formed(html: str) -> bool:
 
     for tag in tag_list:
         if "/" not in tag:
-            cleaned_tag = re.sub(r"(<(\w+)[^>!]*>)", r"<\2>", tag)
+            cleaned_tag = re.sub(r"(<([\w\-]+)[^>!]*>)", r"<\2>", tag)
 
             if cleaned_tag not in EMPTY_ELEMENTS:
                 stack.append(cleaned_tag)


### PR DESCRIPTION
This pull request extends the regex in `is_html_well_formed() ` to no longer raise a warning when the template html contains a custom tag.

Some icon libraries, namely ionicons which adds a custom html tag e.g.: ion-icon

> Note that custom element names [require a dash to be used in them](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) (kebab-case); they can't be single words.
[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements#high-level_view)