### PR TITLE
add example for datetime props

### DIFF
--- a/django_unicorn/call_method_parser.py
+++ b/django_unicorn/call_method_parser.py
@@ -1,30 +1,13 @@
 import ast
 import logging
-from datetime import date, datetime, time, timedelta
 from functools import lru_cache
 from types import MappingProxyType
 from typing import Any, Dict, List, Mapping, Tuple
-from uuid import UUID
 
-from django.utils.dateparse import (
-    parse_date,
-    parse_datetime,
-    parse_duration,
-    parse_time,
-)
+from django_unicorn.utils import CASTERS
 
 
 logger = logging.getLogger(__name__)
-
-# Functions that attempt to convert something that failed while being parsed by
-# `ast.literal_eval`.
-CASTERS = {
-    datetime: parse_datetime,
-    time: parse_time,
-    date: parse_date,
-    timedelta: parse_duration,
-    UUID: UUID,
-}
 
 
 class InvalidKwarg(Exception):

--- a/example/unicorn/components/objects.py
+++ b/example/unicorn/components/objects.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal as D
 from enum import Enum
 from typing import Optional
@@ -42,6 +42,7 @@ class ObjectsView(UnicornView):
     book = Book(title="The Sandman")
     books = Book.objects.all()
     date_example = now()
+    date_example_with_typehint: datetime = now()
     float_example: float = 1.1
     decimal_example = D("1.1")
     int_example = 4
@@ -54,6 +55,11 @@ class ObjectsView(UnicornView):
         assert type(dt) is datetime
 
         self.date_example = dt
+
+    def add_hour(self):
+        self.date_example_with_typehint = self.date_example_with_typehint + timedelta(
+            hours=1
+        )
 
     def set_dictionary(self, val):
         self.dictionary = val

--- a/example/unicorn/components/test_datetime.py
+++ b/example/unicorn/components/test_datetime.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from django.utils import timezone
+from django_unicorn.components import UnicornView
+
+class TestDatetimeView(UnicornView):
+    dt: datetime = None
+
+    def mount(self):
+        self.dt = timezone.now()
+
+    def foo(self):
+        pass

--- a/example/unicorn/components/test_datetime.py
+++ b/example/unicorn/components/test_datetime.py
@@ -1,6 +1,9 @@
 from datetime import datetime
+
 from django.utils import timezone
+
 from django_unicorn.components import UnicornView
+
 
 class TestDatetimeView(UnicornView):
     dt: datetime = None

--- a/example/unicorn/templates/unicorn/objects.html
+++ b/example/unicorn/templates/unicorn/objects.html
@@ -44,6 +44,13 @@
       <button u:click='check_date("{{ date_example|date:'c' }}")'>check_date (c)</button>
       <button u:click='check_date({{ date_example|date:'U' }})'>check_date (U)</button>
     </div>
+
+    <div>
+      {{ date_example_with_typehint }}
+    </div>
+    <div>
+      <button u:click='add_hour()'>add_hour()</button>
+    </div>
   </div>
 
   <div>

--- a/example/unicorn/templates/unicorn/test-datetime.html
+++ b/example/unicorn/templates/unicorn/test-datetime.html
@@ -1,7 +1,7 @@
 {% load unicorn %}
 <div>
-    <div style="width:200px;height:200px;margin:10px;background-color:#aaffaa" unicorn:click="foo()">
-        {{ dt }}<br>
-        (click me)
-    </div>
+  <div style="width:200px;height:200px;margin:10px;background-color:#aaffaa" unicorn:click="foo()">
+    {{ dt }}<br>
+    (click me)
+  </div>
 </div>

--- a/example/unicorn/templates/unicorn/test-datetime.html
+++ b/example/unicorn/templates/unicorn/test-datetime.html
@@ -1,0 +1,7 @@
+{% load unicorn %}
+<div>
+    <div style="width:200px;height:200px;margin:10px;background-color:#aaffaa" unicorn:click="foo()">
+        {{ dt }}<br>
+        (click me)
+    </div>
+</div>

--- a/example/www/templates/www/test-datetime.html
+++ b/example/www/templates/www/test-datetime.html
@@ -1,0 +1,10 @@
+{% extends "www/base.html" %}
+{% load static unicorn %}
+
+{% block content %}
+
+<h2>Test Datetime</h2>
+
+{% unicorn 'test-datetime' %}
+
+{% endblock content %}

--- a/tests/call_method_parser/test_parse_args.py
+++ b/tests/call_method_parser/test_parse_args.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from uuid import UUID
 
-import pytest
-
 from django_unicorn.call_method_parser import eval_value
 
 

--- a/tests/views/utils/test_set_property_from_data.py
+++ b/tests/views/utils/test_set_property_from_data.py
@@ -13,7 +13,8 @@ from example.coffee.models import Flavor
 class FakeComponent(UnicornView):
     string = "property_view"
     integer = 99
-    datetime = datetime(2020, 1, 1)
+    datetime_without_typehint = datetime(2020, 1, 1)
+    datetime_with_typehint: datetime = datetime(2020, 2, 1)
     array: List[str] = []
     model = Flavor(name="test-initial")
     queryset = Flavor.objects.none()
@@ -69,11 +70,22 @@ def test_set_property_from_data_int():
 
 def test_set_property_from_data_datetime():
     component = FakeComponent(component_name="test", component_id="12345678")
-    assert datetime(2020, 1, 1) == component.datetime
+    assert datetime(2020, 1, 1) == component.datetime_without_typehint
 
-    set_property_from_data(component, "datetime", datetime(2020, 1, 2))
+    set_property_from_data(component, "datetime_without_typehint", datetime(2020, 1, 2))
 
-    assert datetime(2020, 1, 2) == component.datetime
+    assert datetime(2020, 1, 2) == component.datetime_without_typehint
+
+
+def test_set_property_from_data_datetime_with_typehint():
+    component = FakeComponent(component_name="test", component_id="12345678")
+    assert datetime(2020, 2, 1) == component.datetime_with_typehint
+
+    set_property_from_data(
+        component, "datetime_with_typehint", str(datetime(2020, 2, 2))
+    )
+
+    assert datetime(2020, 2, 2) == component.datetime_with_typehint
 
 
 def test_set_property_from_data_list():


### PR DESCRIPTION
This adds a page to the `example` folder that shows the issue of issue #514 persisting.

Checkout this branch, open `/test-datetime` and see the green button:

![image](https://github.com/adamghill/django-unicorn/assets/550218/cd385cf6-588f-496b-9d2c-24c980c03eca)

Click it, and the datetime turns into a str:

![image](https://github.com/adamghill/django-unicorn/assets/550218/5e6415db-d672-48b0-a639-7c623b4637a8)
 