### PR TITLE
add example for issue 579

### DIFF
--- a/example/unicorn/components/child.py
+++ b/example/unicorn/components/child.py
@@ -1,0 +1,7 @@
+from datetime import datetime
+from django_unicorn.components import UnicornView
+
+class ChildView(UnicornView):
+    def foo(self):
+        print("child clicked, calling parent's foo()")
+        self.parent.foo()

--- a/example/unicorn/components/parent.py
+++ b/example/unicorn/components/parent.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+from django.utils import timezone
+from django_unicorn.components import UnicornView
+
+class ParentView(UnicornView):
+    def mount(self):
+        print("parent mount: request=", self.request)
+
+
+    def foo(self):
+        print("parent click: request=", self.request)

--- a/example/unicorn/templates/unicorn/child.html
+++ b/example/unicorn/templates/unicorn/child.html
@@ -1,0 +1,5 @@
+<div>
+    <div style="width:100px;height:100px;margin:10px;background-color:#ffaaaa" unicorn:click="foo()">
+        Child
+    </div>
+</div>

--- a/example/unicorn/templates/unicorn/parent.html
+++ b/example/unicorn/templates/unicorn/parent.html
@@ -1,0 +1,10 @@
+{% load unicorn %}
+<div>
+    <div style="width:200px;height:200px;margin:10px;background-color:#aaffaa" unicorn:click="foo()">
+        Parent
+    </div>
+
+    <hr>
+
+    {% unicorn "child" dt=foobar parent=view %}
+</div>

--- a/example/www/templates/www/base.html
+++ b/example/www/templates/www/base.html
@@ -43,6 +43,7 @@
       <li><a href="{% url 'www:template' 'js' %}">JavaScript integration</a></li>
       <li><a href="{% url 'www:direct-view' %}">Direct View</a></li>
       <li><a href="{% url 'www:redirects' %}">Redirects</a></li>
+      <li><a href="{% url 'www:template' 'parent' %}">Test Parent/Child</a></li>
     </ul>
 
     {% block content %}{% endblock content %}

--- a/example/www/templates/www/parent.html
+++ b/example/www/templates/www/parent.html
@@ -1,0 +1,12 @@
+{% extends "www/base.html" %}
+{% load static unicorn %}
+
+{% block content %}
+
+<h2>Parent/Child</h2>
+
+This is the "parent" component, which in turn loads the "child" component. Click each.
+
+{% unicorn 'parent' %}
+
+{% endblock content %}


### PR DESCRIPTION
This adds an example for issue #579. The parent's `request` attribute is properly set during mount and when its `foo` method is triggered directly via click, but is `None` when the child triggers the parent's `foo` method.