### PR TITLE
Set the component's parent request explicitly

### DIFF
--- a/django_unicorn/views/__init__.py
+++ b/django_unicorn/views/__init__.py
@@ -86,9 +86,13 @@ def _process_component_request(
         request=request,
     )
 
-    # This shouldn't happen, but is a fail-safe to make sure that there is always a request on the component
+    # Make sure that there is always a request on the component if needed
     if component.request is None:
         component.request = request
+
+    # Make sure that there is always a request on the parent if needed
+    if component.parent is not None and component.parent.request is None:
+        component.parent.request = request
 
     # Get a deepcopy of the data passed in to determine what fields are updated later
     original_data = copy.deepcopy(component_request.data)


### PR DESCRIPTION
This will make sure a component's parent request is set to the current request. Solves for https://github.com/adamghill/django-unicorn/issues/579.