### PR TITLE
Fixing erroneous installation instructions

### DIFF
--- a/django_unicorn/settings.py
+++ b/django_unicorn/settings.py
@@ -76,7 +76,7 @@ def get_minify_html_enabled():
             import htmlmin
         except ModuleNotFoundError:
             logger.error(
-                "MINIFY_HTML is `True`, but minify extra could not be imported. Install with `unicorn[minify]`."
+                "MINIFY_HTML is `True`, but minify extra could not be imported. Install with `django-unicorn[minify]`."
             )
 
             return False


### PR DESCRIPTION
When `MINIFY_HTML` is set to `True`, but `htmlmin` is not installed, 
the following warning is printed:

```
MINIFY_HTML is `True`, but minify extra could not be imported. Install with `unicorn[minify]`.
MINIFY_HTML is `True`, but minify extra could not be imported. Install with `unicorn[minify]`.
```

Users should be instructed to install `django-unicorn[minify] instead of `unicorn[minify]`