### PR TITLE
Remove dataclasses as a dependency for Python versions below 3.7.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2166,4 +2166,4 @@ minify = ["htmlmin"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "f8b19092daede62d927f8611aea6a0bdf1a0083eccc579368ced9fcbe3973f19"
+content-hash = "964a3eac9a00cb610e1cad707710c36dc7bc12e3892fa1872ed54ff4b16de0d3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ beautifulsoup4 = ">=4.8.0"
 orjson = "^3.6.0"
 shortuuid = "^1.0.1"
 cachetools = "^4.1.1"
-dataclasses = {version = "^0.8.0", python = "<3.7"}
 decorator = "^4.4.2"
 htmlmin = { version = "^0.1.12", optional = true }
 


### PR DESCRIPTION
Since the project explicitly supports Python 3.8 and above, this should not be necessary.