### PR TITLE
Run tests for Python 3.11 in GitHub Actions.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
Assuming that we support Python 3.11, it is beneficial to run the tests for this version too.