### PR TITLE
`ruff` fixes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,10 @@ jobs:
         run: poetry install
 
       - name: black check
-        run: poetry run black . --check --extend-exclude migrations
+        run: poetry run black . --check
+
+      - name: ruff check
+        run: poetry run ruff .
 
       - name: Run all tests
         run: poetry run nox

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
-from django.conf import settings
-
 import pytest
+from django.conf import settings
 
 
 def pytest_configure():

--- a/django_unicorn/call_method_parser.py
+++ b/django_unicorn/call_method_parser.py
@@ -6,11 +6,10 @@ from typing import Any, Dict, List, Mapping, Tuple
 
 from django_unicorn.utils import CASTERS
 
-
 logger = logging.getLogger(__name__)
 
 
-class InvalidKwarg(Exception):
+class InvalidKwargError(Exception):
     pass
 
 
@@ -85,7 +84,7 @@ def eval_value(value):
 
 
 @lru_cache(maxsize=128, typed=True)
-def parse_kwarg(kwarg: str, raise_if_unparseable=False) -> Dict[str, Any]:
+def parse_kwarg(kwarg: str, *, raise_if_unparseable=False) -> Dict[str, Any]:
     """
     Parses a potential kwarg as a string into a dictionary.
 
@@ -121,9 +120,9 @@ def parse_kwarg(kwarg: str, raise_if_unparseable=False) -> Dict[str, Any]:
                 value = _get_expr_string(assign.value)
                 return {target.id: value}
         else:
-            raise InvalidKwarg(f"'{kwarg}' is invalid")
-    except SyntaxError:
-        raise InvalidKwarg(f"'{kwarg}' could not be parsed")
+            raise InvalidKwargError(f"'{kwarg}' is invalid")
+    except SyntaxError as e:
+        raise InvalidKwargError(f"'{kwarg}' could not be parsed") from e
 
 
 @lru_cache(maxsize=128, typed=True)

--- a/django_unicorn/components/__init__.py
+++ b/django_unicorn/components/__init__.py
@@ -1,8 +1,7 @@
-from .mixins import ModelValueMixin
-from .typing import QuerySetType
-from .unicorn_view import UnicornField, UnicornView
-from .updaters import HashUpdate, LocationUpdate, PollUpdate
-
+from django_unicorn.components.mixins import ModelValueMixin
+from django_unicorn.components.typing import QuerySetType
+from django_unicorn.components.unicorn_view import UnicornField, UnicornView
+from django_unicorn.components.updaters import HashUpdate, LocationUpdate, PollUpdate
 
 __all__ = [
     "QuerySetType",

--- a/django_unicorn/components/typing.py
+++ b/django_unicorn/components/typing.py
@@ -2,7 +2,6 @@ from typing import Generic, Iterator, TypeVar
 
 from django.db.models import Model, QuerySet
 
-
 M_co = TypeVar("M_co", bound=Model, covariant=True)
 
 

--- a/django_unicorn/components/updaters.py
+++ b/django_unicorn/components/updaters.py
@@ -1,7 +1,7 @@
 import logging
+from typing import Optional
 
 from django.http.response import HttpResponseRedirect
-
 
 logger = logging.getLogger(__name__)
 
@@ -20,12 +20,12 @@ class HashUpdate(Update):
     Updates the current URL hash from an action method.
     """
 
-    def __init__(self, hash: str):
+    def __init__(self, url_hash: str):
         """
         Args:
-            param hash: The hash to change. Example: `#model-123`.
+            param url_hash: The URL hash to change. Example: `#model-123`.
         """
-        self.hash = hash
+        self.hash = url_hash
 
 
 class LocationUpdate(Update):
@@ -33,7 +33,7 @@ class LocationUpdate(Update):
     Updates the current URL from an action method.
     """
 
-    def __init__(self, redirect: HttpResponseRedirect, title: str = None):
+    def __init__(self, redirect: HttpResponseRedirect, title: Optional[str] = None):
         """
         Args:
             param redirect: The redirect that contains the URL to redirect to.
@@ -48,7 +48,7 @@ class PollUpdate(Update):
     Updates the current poll from an action method.
     """
 
-    def __init__(self, timing: int = None, method: str = None, disable: bool = False):
+    def __init__(self, *, timing: Optional[int] = None, method: Optional[str] = None, disable: bool = False):
         """
         Args:
             param timing: The timing that should be used for the poll. Optional. Defaults to `None`

--- a/django_unicorn/db.py
+++ b/django_unicorn/db.py
@@ -1,8 +1,12 @@
+from typing import Optional
+
 from django.db.models import Model
 
 
 class DbModel:
-    def __init__(self, name: str, model_class: Model, *, defaults: dict = {}):
+    def __init__(self, name: str, model_class: Model, *, defaults: Optional[dict] = None):
+        if defaults is None:
+            defaults = {}
         self.name = name
         self.model_class = model_class
         self.defaults = defaults

--- a/django_unicorn/decorators.py
+++ b/django_unicorn/decorators.py
@@ -1,9 +1,8 @@
 import logging
 import time
 
-from django.conf import settings
-
 from decorator import decorator
+from django.conf import settings
 
 
 @decorator
@@ -29,7 +28,7 @@ def timed(func, *args, **kwargs):
 
     for kwarg_key, kwarg_val in kwargs.items():
         if isinstance(kwarg_val, str):
-            kwarg_val = f"'{kwarg_val}'"
+            kwarg_val = f"'{kwarg_val}'"  # noqa: PLW2901
 
         arguments = f"{arguments}{kwarg_key}={kwarg_val}, "
 

--- a/django_unicorn/errors.py
+++ b/django_unicorn/errors.py
@@ -20,17 +20,17 @@ class ComponentClassLoadError(ComponentLoadError):
     pass
 
 
-class RenderNotModified(Exception):
+class RenderNotModifiedError(Exception):
     pass
 
 
-class MissingComponentElement(Exception):
+class MissingComponentElementError(Exception):
     pass
 
 
-class MissingComponentViewElement(Exception):
+class MissingComponentViewElementError(Exception):
     pass
 
 
-class ComponentNotValid(Exception):
+class ComponentNotValidError(Exception):
     pass

--- a/django_unicorn/management/commands/startunicorn.py
+++ b/django_unicorn/management/commands/startunicorn.py
@@ -12,7 +12,6 @@ from django_unicorn.components.unicorn_view import (
     convert_to_snake_case,
 )
 
-
 COMPONENT_FILE_CONTENT = """from django_unicorn.components import UnicornView
 
 
@@ -35,15 +34,13 @@ def get_app_path(app_name: str) -> Path:
 
 
 class Command(BaseCommand):
-    help = "Creates a new component for `django-unicorn`"
+    help = "Creates a new component for `django-unicorn`"  # noqa: A003
 
     def add_arguments(self, parser):
         parser.add_argument("app_name", type=str)
-        parser.add_argument(
-            "component_names", nargs="+", type=str, help="Names of components"
-        )
+        parser.add_argument("component_names", nargs="+", type=str, help="Names of components")
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         # Default from `django-cookiecutter`
         base_path = getattr(settings, "APPS_DIR", None)
 
@@ -68,7 +65,7 @@ class Command(BaseCommand):
 
         try:
             app_directory = get_app_path(app_name)
-        except LookupError:
+        except LookupError as e:
             should_create_app = input(
                 f"\n'{app_name}' cannot be found. Should it be created automatically with `startapp {app_name}`? [y/N] "
             )
@@ -85,7 +82,7 @@ class Command(BaseCommand):
             else:
                 raise CommandError(
                     f"An app named '{app_name}' does not exist yet. You might need to create it first."
-                )
+                ) from e
 
         is_first_component = False
 
@@ -98,9 +95,7 @@ class Command(BaseCommand):
         if not component_base_path.exists():
             component_base_path.mkdir()
 
-            self.stdout.write(
-                self.style.SUCCESS(f"Created your first component in '{app_name}'! ✨\n")
-            )
+            self.stdout.write(self.style.SUCCESS(f"Created your first component in '{app_name}'! ✨\n"))
 
             is_first_component = True
 
@@ -110,7 +105,7 @@ class Command(BaseCommand):
 
         for component_name in options["component_names"]:
             if "." in component_name:
-                (*nested_paths, component_name) = component_name.split(".")
+                (*nested_paths, component_name) = component_name.split(".")  # noqa: PLW2901
 
                 for nested_path in nested_paths:
                     component_base_path /= nested_path
@@ -127,15 +122,11 @@ class Command(BaseCommand):
 
             if component_path.exists():
                 self.stdout.write(
-                    self.style.ERROR(
-                        f"Skipping creating {snake_case_component_name}.py because it already exists."
-                    )
+                    self.style.ERROR(f"Skipping creating {snake_case_component_name}.py because it already exists.")
                 )
             else:
                 component_path.write_text(
-                    COMPONENT_FILE_CONTENT.format(
-                        **{"pascal_case_component_name": pascal_case_component_name}
-                    )
+                    COMPONENT_FILE_CONTENT.format(**{"pascal_case_component_name": pascal_case_component_name})
                 )
                 self.stdout.write(self.style.SUCCESS(f"Created {component_path}."))
 
@@ -158,9 +149,7 @@ class Command(BaseCommand):
 
             if template_path.exists():
                 self.stdout.write(
-                    self.style.ERROR(
-                        f"Skipping creating {component_name}.html because it already exists."
-                    )
+                    self.style.ERROR(f"Skipping creating {component_name}.html because it already exists.")
                 )
             else:
                 template_path.write_text(TEMPLATE_FILE_CONTENT)
@@ -172,11 +161,7 @@ class Command(BaseCommand):
                 )
 
                 if will_star_repo.strip().lower() in ("y", "yes"):
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            "Thank you for helping spread the word about Unicorn!"
-                        )
-                    )
+                    self.stdout.write(self.style.SUCCESS("Thank you for helping spread the word about Unicorn!"))
 
                     self.stdout.write(
                         """
@@ -199,19 +184,12 @@ class Command(BaseCommand):
 """
                     )
 
-                    webbrowser.open(
-                        "https://github.com/adamghill/django-unicorn", new=2
-                    )
+                    webbrowser.open("https://github.com/adamghill/django-unicorn", new=2)
                 else:
                     self.stdout.write(
-                        self.style.ERROR(
-                            "That's a bummer, but I understand. I hope you will star it for me later!"
-                        )
+                        self.style.ERROR("That's a bummer, but I understand. I hope you will star it for me later!")
                     )
 
             if is_new_app:
-                self.stdout.write(
-                    self.style.WARNING(
-                        f'\nMake sure to add `"{app_name}",` to your INSTALLED_APPS list in your settings file if necessary.'
-                    )
-                )
+                msg = f'\nMake sure to add `"{app_name}",` to your INSTALLED_APPS list in your settings file if necessary.'  # noqa: E501
+                self.stdout.write(self.style.WARNING(msg))

--- a/django_unicorn/settings.py
+++ b/django_unicorn/settings.py
@@ -2,7 +2,6 @@ import logging
 
 from django.conf import settings
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/django_unicorn/urls.py
+++ b/django_unicorn/urls.py
@@ -1,14 +1,11 @@
 from django.urls import path, re_path
 
-from . import views
-
+from django_unicorn import views
 
 app_name = "django_unicorn"
 
 
 urlpatterns = (
-    re_path("message/(?P<component_name>[\w/\.-]+)", views.message, name="message"),
-    path(
-        "message", views.message, name="message"
-    ),  # Only here to build the correct url in scripts.html
+    re_path(r"message/(?P<component_name>[\w/\.-]+)", views.message, name="message"),
+    path("message", views.message, name="message"),  # Only here to build the correct url in scripts.html
 )

--- a/django_unicorn/utils.py
+++ b/django_unicorn/utils.py
@@ -2,13 +2,14 @@ import collections.abc
 import hmac
 import logging
 import pickle
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from inspect import signature
 from pprint import pprint
 from typing import Dict, List, Union
 from typing import get_type_hints as typing_get_type_hints
 from uuid import UUID
 
+import shortuuid
 from django.conf import settings
 from django.core.cache import caches
 from django.http import HttpRequest
@@ -19,14 +20,11 @@ from django.utils.dateparse import (
     parse_time,
 )
 from django.utils.html import _json_script_escapes
-from django.utils.safestring import mark_safe
-
-import shortuuid
+from django.utils.safestring import SafeText, mark_safe
 
 import django_unicorn
 from django_unicorn.errors import UnicornCacheError
 from django_unicorn.settings import get_cache_alias
-
 
 try:
     from typing import get_args, get_origin
@@ -89,20 +87,16 @@ def dicts_equal(dictionary_one: Dict, dictionary_two: Dict) -> bool:
     Return True if all keys and values are the same between two dictionaries.
     """
 
-    is_valid = all(
-        k in dictionary_two and dictionary_one[k] == dictionary_two[k]
-        for k in dictionary_one
-    ) and all(
-        k in dictionary_one and dictionary_one[k] == dictionary_two[k]
-        for k in dictionary_two
+    is_valid = all(k in dictionary_two and dictionary_one[k] == dictionary_two[k] for k in dictionary_one) and all(
+        k in dictionary_one and dictionary_one[k] == dictionary_two[k] for k in dictionary_two
     )
 
     if not is_valid:
-        print("dictionary_one:")
-        pprint(dictionary_one)
-        print()
-        print("dictionary_two:")
-        pprint(dictionary_two)
+        print("dictionary_one:")  # noqa: T201
+        pprint(dictionary_one)  # noqa: T203
+        print()  # noqa: T201
+        print("dictionary_two:")  # noqa: T201
+        pprint(dictionary_two)  # noqa: T203
 
     return is_valid
 
@@ -127,9 +121,7 @@ def cache_full_tree(component: "django_unicorn.views.UnicornView"):
             cache.set(component.component_cache_key, component)
 
 
-def restore_from_cache(
-    component_cache_key: str, request: HttpRequest = None
-) -> "django_unicorn.views.UnicornView":
+def restore_from_cache(component_cache_key: str, request: HttpRequest = None) -> "django_unicorn.views.UnicornView":
     """
     Gets a cached unicorn view by key, restoring and getting cached parents and children
     and setting the request.
@@ -158,10 +150,11 @@ def restore_from_cache(
 
             for index, child in enumerate(current.children):
                 key = child.component_cache_key
-                child = roots.pop(key, None) or cache.get(key)
-                child.parent = current
-                current.children[index] = child
-                to_traverse.append(child)
+                cached_child = roots.pop(key, None) or cache.get(key)
+
+                cached_child.parent = current
+                current.children[index] = cached_child
+                to_traverse.append(cached_child)
 
     return cached_component
 
@@ -206,15 +199,11 @@ class CacheableComponent:
 
             if component.parent:
                 components.append(component.parent)
-                component.parent = PointerUnicornView(
-                    component.parent.component_cache_key
-                )
+                component.parent = PointerUnicornView(component.parent.component_cache_key)
 
             for index, child in enumerate(component.children):
                 components.append(child)
-                component.children[index] = PointerUnicornView(
-                    child.component_cache_key
-                )
+                component.children[index] = PointerUnicornView(child.component_cache_key)
 
         for component, *_ in self._state.values():
             try:
@@ -308,11 +297,9 @@ def cast_value(type_hint, value):
                 value = caster(value)
                 break
             except TypeError:
-                if (type_hint is datetime or type_hint is date) and (
-                    isinstance(value, int) or isinstance(value, float)
-                ):
+                if (type_hint is datetime or type_hint is date) and (isinstance(value, (float, int))):
                     try:
-                        value = datetime.fromtimestamp(value)
+                        value = datetime.fromtimestamp(value, tz=timezone.utc)
 
                         if type_hint is date:
                             value = value.date()
@@ -344,7 +331,7 @@ def get_method_arguments(func) -> List[str]:
     return function_signature_cache[func]
 
 
-def sanitize_html(str):
+def sanitize_html(html: str) -> SafeText:
     """
     Escape all the HTML/XML special characters with their unicode escapes, so
     value is safe to be output in JSON.
@@ -353,8 +340,8 @@ def sanitize_html(str):
     instead of an object to avoid calling DjangoJSONEncoder.
     """
 
-    str = str.translate(_json_script_escapes)
-    return mark_safe(str)
+    html = html.translate(_json_script_escapes)
+    return mark_safe(html)  # noqa: S308
 
 
 def is_non_string_sequence(obj):
@@ -363,10 +350,9 @@ def is_non_string_sequence(obj):
     Helpful when you expect to loop over `obj`, but explicitly don't want to allow `str`.
     """
 
-    if (
-        isinstance(obj, collections.abc.Sequence)
-        or isinstance(obj, collections.abc.Set)
-    ) and not isinstance(obj, (str, bytes, bytearray)):
+    if (isinstance(obj, (collections.abc.Sequence, collections.abc.Set))) and not isinstance(
+        obj, (str, bytes, bytearray)
+    ):
         return True
 
     return False

--- a/django_unicorn/views/action_parsers/sync_input.py
+++ b/django_unicorn/views/action_parsers/sync_input.py
@@ -1,9 +1,8 @@
 from typing import Dict
 
 from django_unicorn.components import UnicornView
+from django_unicorn.views.action_parsers.utils import set_property_value
 from django_unicorn.views.objects import ComponentRequest
-
-from .utils import set_property_value
 
 
 def handle(component_request: ComponentRequest, component: UnicornView, payload: Dict):

--- a/django_unicorn/views/action_parsers/utils.py
+++ b/django_unicorn/views/action_parsers/utils.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict, Optional
 
 from django.db.models import QuerySet
 
@@ -8,7 +8,10 @@ from django_unicorn.decorators import timed
 
 @timed
 def set_property_value(
-    component: UnicornView, property_name: str, property_value: Any, data: dict = None
+    component: UnicornView,
+    property_name: str,
+    property_value: Any,
+    data: Optional[Dict] = None,
 ) -> None:
     """
     Sets properties on the component.
@@ -21,8 +24,10 @@ def set_property_value(
         param data: Dictionary that gets sent back with the response. Defaults to {}.
     """
 
-    assert property_name is not None, "Property name is required"
-    assert property_value is not None, "Property value is required"
+    if property_name is None:
+        raise AssertionError("Property name is required")
+    if property_value is None:
+        raise AssertionError("Property value is required")
 
     if not data:
         data = {}
@@ -76,14 +81,10 @@ def set_property_value(
                                 related_name = field.name
 
                                 if field.auto_created:
-                                    related_name = (
-                                        field.related_name or f"{field.name}_set"
-                                    )
+                                    related_name = field.related_name or f"{field.name}_set"
 
                                 if related_name == property_name_part:
-                                    related_descriptor = getattr(
-                                        component_or_field, related_name
-                                    )
+                                    related_descriptor = getattr(component_or_field, related_name)
                                     related_descriptor.set(property_value)
                                     is_relation_field = True
                                     break
@@ -114,18 +115,16 @@ def set_property_value(
             else:
                 component_or_field = component_or_field[property_name_part]
                 data_or_dict = data_or_dict.get(property_name_part, {})
-        elif isinstance(component_or_field, list) or isinstance(
-            component_or_field, QuerySet
-        ):
-            # TODO: Check for iterable instad of list? `from collections.abc import Iterable`
-            property_name_part = int(property_name_part)
+        elif isinstance(component_or_field, (QuerySet, list)):
+            # TODO: Check for iterable instead of list? `from collections.abc import Iterable`
+            property_name_part_int = int(property_name_part)
 
             if idx == len(property_name_parts) - 1:
-                component_or_field[property_name_part] = property_value
-                data_or_dict[property_name_part] = property_value
+                component_or_field[property_name_part_int] = property_value
+                data_or_dict[property_name_part_int] = property_value
             else:
-                component_or_field = component_or_field[property_name_part]
-                data_or_dict = data_or_dict[property_name_part]
+                component_or_field = component_or_field[property_name_part_int]
+                data_or_dict = data_or_dict[property_name_part_int]
         else:
             break
 

--- a/django_unicorn/views/objects.py
+++ b/django_unicorn/views/objects.py
@@ -7,7 +7,6 @@ from django_unicorn.errors import UnicornViewError
 from django_unicorn.serializer import JSONDecodeError, dumps, loads
 from django_unicorn.utils import generate_checksum
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -23,10 +22,7 @@ class Action:
         self.partials = data.get("partials", [])
 
     def __repr__(self):
-        return (
-            f"Action(action_type='{self.action_type}' payload={self.payload}"
-            f" partials={self.partials})"
-        )
+        return f"Action(action_type='{self.action_type}' payload={self.payload} partials={self.partials})"
 
 
 def is_int(s):
@@ -39,12 +35,7 @@ def is_int(s):
 
 
 def sort_dict(d):
-    items = [
-        [k, v]
-        for k, v in sorted(
-            d.items(), key=lambda x: x[0] if not is_int(x[0]) else int(x[0])
-        )
-    ]
+    items = [[k, v] for k, v in sorted(d.items(), key=lambda x: x[0] if not is_int(x[0]) else int(x[0]))]
 
     for item in items:
         if isinstance(item[1], dict):
@@ -64,21 +55,27 @@ class ComponentRequest:
 
         try:
             self.body = loads(request.body)
-            assert self.body, "Invalid JSON body"
+
+            if not self.body:
+                raise AssertionError("Invalid JSON body")
         except JSONDecodeError as e:
             raise UnicornViewError("Body could not be parsed") from e
 
         self.name = component_name
-        assert self.name, "Missing component name"
+        if not self.name:
+            raise AssertionError("Missing component name")
 
         self.data = self.body.get("data")
-        assert self.data is not None, "Missing data"  # data could theoretically be {}
+        if not self.data is not None:
+            raise AssertionError("Missing data")  # data could theoretically be {}
 
         self.id = self.body.get("id")
-        assert self.id, "Missing component id"
+        if not self.id:
+            raise AssertionError("Missing component id")
 
         self.epoch = self.body.get("epoch", "")
-        assert self.epoch, "Missing epoch"
+        if not self.epoch:
+            raise AssertionError("Missing epoch")
 
         self.key = self.body.get("key", "")
         self.hash = self.body.get("hash", "")
@@ -104,10 +101,16 @@ class ComponentRequest:
             Raises `AssertionError` if the checksums don't match.
         """
         checksum = self.body.get("checksum")
-        assert checksum, "Missing checksum"
+
+        if not checksum:
+            # TODO: Raise specific exception
+            raise AssertionError("Missing checksum")
 
         generated_checksum = generate_checksum(str(self.data))
-        assert checksum == generated_checksum, "Checksum does not match"
+
+        if checksum != generated_checksum:
+            # TODO: Raise specific exception
+            raise AssertionError("Checksum does not match")
 
 
 class Return:

--- a/django_unicorn/views/utils.py
+++ b/django_unicorn/views/utils.py
@@ -10,7 +10,6 @@ from django_unicorn.decorators import timed
 from django_unicorn.utils import get_type_hints
 from django_unicorn.views.action_parsers.call_method import cast_value
 
-
 try:
     from typing import get_args, get_origin
 except ImportError:
@@ -46,9 +45,7 @@ def set_property_from_data(
         return
 
     field = getattr(component_or_field, name)
-    component_field_is_model_or_unicorn_field = (
-        _is_component_field_model_or_unicorn_field(component_or_field, name)
-    )
+    component_field_is_model_or_unicorn_field = _is_component_field_model_or_unicorn_field(component_or_field, name)
 
     # UnicornField and Models are always a dictionary (can be nested)
     if component_field_is_model_or_unicorn_field:
@@ -82,9 +79,7 @@ def set_property_from_data(
 
         if hasattr(component_or_field, "_set_property"):
             # Can assume that `component_or_field` is a component
-            component_or_field._set_property(
-                name, value, call_updating_method=True, call_updated_method=False
-            )
+            component_or_field._set_property(name, value, call_updating_method=True, call_updated_method=False)
         else:
             setattr(component_or_field, name, value)
 
@@ -110,7 +105,7 @@ def _is_component_field_model_or_unicorn_field(
     """
     field = getattr(component_or_field, name)
 
-    if isinstance(field, UnicornField) or isinstance(field, Model):
+    if isinstance(field, (Model, UnicornField)):
         return True
 
     is_subclass_of_model = False
@@ -124,9 +119,7 @@ def _is_component_field_model_or_unicorn_field(
             is_subclass_of_model = issubclass(component_type_hints[name], Model)
 
             if not is_subclass_of_model:
-                is_subclass_of_unicorn_field = issubclass(
-                    component_type_hints[name], UnicornField
-                )
+                is_subclass_of_unicorn_field = issubclass(component_type_hints[name], UnicornField)
 
             # Construct a new class if the field is None and there is a type hint available
             if field is None:
@@ -145,10 +138,9 @@ def _is_queryset(field, type_hint, value):
     component or the type hint.
     """
 
-    return (
-        isinstance(field, QuerySet)
-        or (type_hint and get_origin(type_hint) is QuerySetType)
-    ) and isinstance(value, list)
+    return (isinstance(field, QuerySet) or (type_hint and get_origin(type_hint) is QuerySetType)) and isinstance(
+        value, list
+    )
 
 
 def _create_queryset(field, type_hint, value) -> QuerySet:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,5 @@
 import toml
 
-
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -17,7 +16,7 @@ import toml
 # -- Project information -----------------------------------------------------
 
 project = "Unicorn"
-copyright = "2021, Adam Hill"
+copyright = "2021, Adam Hill"  # noqa: A001
 author = "Adam Hill"
 
 pyproject = toml.load("../../pyproject.toml")

--- a/example/coffee/models.py
+++ b/example/coffee/models.py
@@ -8,9 +8,7 @@ class Flavor(models.Model):
     label = models.CharField(max_length=255)
     parent = models.ForeignKey("self", blank=True, null=True, on_delete=models.SET_NULL)
     float_value = models.FloatField(blank=True, null=True)
-    decimal_value = models.DecimalField(
-        blank=True, null=True, max_digits=10, decimal_places=2
-    )
+    decimal_value = models.DecimalField(blank=True, null=True, max_digits=10, decimal_places=2)
     uuid = models.UUIDField(default=uuid.uuid4)
     datetime = models.DateTimeField(blank=True, null=True)
     date = models.DateField(blank=True, null=True)

--- a/example/unicorn/components/nested/filter.py
+++ b/example/unicorn/components/nested/filter.py
@@ -8,6 +8,4 @@ class FilterView(UnicornView):
         self.parent.load_table()
 
         if query:
-            self.parent.flavors = list(
-                filter(lambda f: query.lower() in f.name.lower(), self.parent.flavors)
-            )
+            self.parent.flavors = list(filter(lambda f: query.lower() in f.name.lower(), self.parent.flavors))

--- a/example/unicorn/components/nested/table.py
+++ b/example/unicorn/components/nested/table.py
@@ -28,13 +28,7 @@ class TableView(UnicornView):
 
     def load_table(self):
         self.flavors = Flavor.objects.select_related("favorite").all()[10:20]
-        self.favorite_count = sum(
-            [
-                1
-                for f in self.flavors
-                if hasattr(f, "favorite") and f.favorite.is_favorite
-            ]
-        )
+        self.favorite_count = sum([1 for f in self.flavors if hasattr(f, "favorite") and f.favorite.is_favorite])
 
         def set_unedit(c):
             if hasattr(c, "is_editing"):

--- a/example/unicorn/components/objects.py
+++ b/example/unicorn/components/objects.py
@@ -67,9 +67,7 @@ class ObjectsView(UnicornView):
         self.date_example = dt
 
     def add_hour(self):
-        self.date_example_with_typehint = self.date_example_with_typehint + timedelta(
-            hours=1
-        )
+        self.date_example_with_typehint = self.date_example_with_typehint + timedelta(hours=1)
 
     def set_dictionary(self, val):
         self.dictionary = val

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,19 +1,9 @@
-import sys
-
 import nox
 
 
 @nox.session()
 @nox.parametrize("django", ["3.2", "4.1", "4.2"])
 def tests(session, django):
-    # Skip testing Django 4.0 with Python 3.7 because it is unsupported
-    if (
-        django.startswith("4.")
-        and sys.version_info.major == 3
-        and sys.version_info.minor == 7
-    ):
-        return
-
     session.install("poetry")
     session.run("poetry", "install", "-E", "minify")
     session.install(f"django=={django}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -143,33 +143,33 @@ lxml = ["lxml"]
 
 [[package]]
 name = "black"
-version = "23.7.0"
+version = "23.9.1"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "black-23.7.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:5c4bc552ab52f6c1c506ccae05681fab58c3f72d59ae6e6639e8885e94fe2587"},
-    {file = "black-23.7.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:552513d5cd5694590d7ef6f46e1767a4df9af168d449ff767b13b084c020e63f"},
-    {file = "black-23.7.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:86cee259349b4448adb4ef9b204bb4467aae74a386bce85d56ba4f5dc0da27be"},
-    {file = "black-23.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:501387a9edcb75d7ae8a4412bb8749900386eaef258f1aefab18adddea1936bc"},
-    {file = "black-23.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb074d8b213749fa1d077d630db0d5f8cc3b2ae63587ad4116e8a436e9bbe995"},
-    {file = "black-23.7.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:b5b0ee6d96b345a8b420100b7d71ebfdd19fab5e8301aff48ec270042cd40ac2"},
-    {file = "black-23.7.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:893695a76b140881531062d48476ebe4a48f5d1e9388177e175d76234ca247cd"},
-    {file = "black-23.7.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:c333286dc3ddca6fdff74670b911cccedacb4ef0a60b34e491b8a67c833b343a"},
-    {file = "black-23.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:831d8f54c3a8c8cf55f64d0422ee875eecac26f5f649fb6c1df65316b67c8926"},
-    {file = "black-23.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:7f3bf2dec7d541b4619b8ce526bda74a6b0bffc480a163fed32eb8b3c9aed8ad"},
-    {file = "black-23.7.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:f9062af71c59c004cd519e2fb8f5d25d39e46d3af011b41ab43b9c74e27e236f"},
-    {file = "black-23.7.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:01ede61aac8c154b55f35301fac3e730baf0c9cf8120f65a9cd61a81cfb4a0c3"},
-    {file = "black-23.7.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:327a8c2550ddc573b51e2c352adb88143464bb9d92c10416feb86b0f5aee5ff6"},
-    {file = "black-23.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d1c6022b86f83b632d06f2b02774134def5d4d4f1dac8bef16d90cda18ba28a"},
-    {file = "black-23.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:27eb7a0c71604d5de083757fbdb245b1a4fae60e9596514c6ec497eb63f95320"},
-    {file = "black-23.7.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:8417dbd2f57b5701492cd46edcecc4f9208dc75529bcf76c514864e48da867d9"},
-    {file = "black-23.7.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:47e56d83aad53ca140da0af87678fb38e44fd6bc0af71eebab2d1f59b1acf1d3"},
-    {file = "black-23.7.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:25cc308838fe71f7065df53aedd20327969d05671bac95b38fdf37ebe70ac087"},
-    {file = "black-23.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:642496b675095d423f9b8448243336f8ec71c9d4d57ec17bf795b67f08132a91"},
-    {file = "black-23.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:ad0014efc7acf0bd745792bd0d8857413652979200ab924fbf239062adc12491"},
-    {file = "black-23.7.0-py3-none-any.whl", hash = "sha256:9fd59d418c60c0348505f2ddf9609c1e1de8e7493eab96198fc89d9f865e7a96"},
-    {file = "black-23.7.0.tar.gz", hash = "sha256:022a582720b0d9480ed82576c920a8c1dde97cc38ff11d8d8859b3bd6ca9eedb"},
+    {file = "black-23.9.1-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:d6bc09188020c9ac2555a498949401ab35bb6bf76d4e0f8ee251694664df6301"},
+    {file = "black-23.9.1-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:13ef033794029b85dfea8032c9d3b92b42b526f1ff4bf13b2182ce4e917f5100"},
+    {file = "black-23.9.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:75a2dc41b183d4872d3a500d2b9c9016e67ed95738a3624f4751a0cb4818fe71"},
+    {file = "black-23.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13a2e4a93bb8ca74a749b6974925c27219bb3df4d42fc45e948a5d9feb5122b7"},
+    {file = "black-23.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:adc3e4442eef57f99b5590b245a328aad19c99552e0bdc7f0b04db6656debd80"},
+    {file = "black-23.9.1-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:8431445bf62d2a914b541da7ab3e2b4f3bc052d2ccbf157ebad18ea126efb91f"},
+    {file = "black-23.9.1-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:8fc1ddcf83f996247505db6b715294eba56ea9372e107fd54963c7553f2b6dfe"},
+    {file = "black-23.9.1-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:7d30ec46de88091e4316b17ae58bbbfc12b2de05e069030f6b747dfc649ad186"},
+    {file = "black-23.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031e8c69f3d3b09e1aa471a926a1eeb0b9071f80b17689a655f7885ac9325a6f"},
+    {file = "black-23.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:538efb451cd50f43aba394e9ec7ad55a37598faae3348d723b59ea8e91616300"},
+    {file = "black-23.9.1-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:638619a559280de0c2aa4d76f504891c9860bb8fa214267358f0a20f27c12948"},
+    {file = "black-23.9.1-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:a732b82747235e0542c03bf352c126052c0fbc458d8a239a94701175b17d4855"},
+    {file = "black-23.9.1-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:cf3a4d00e4cdb6734b64bf23cd4341421e8953615cba6b3670453737a72ec204"},
+    {file = "black-23.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf99f3de8b3273a8317681d8194ea222f10e0133a24a7548c73ce44ea1679377"},
+    {file = "black-23.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:14f04c990259576acd093871e7e9b14918eb28f1866f91968ff5524293f9c573"},
+    {file = "black-23.9.1-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:c619f063c2d68f19b2d7270f4cf3192cb81c9ec5bc5ba02df91471d0b88c4c5c"},
+    {file = "black-23.9.1-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:6a3b50e4b93f43b34a9d3ef00d9b6728b4a722c997c99ab09102fd5efdb88325"},
+    {file = "black-23.9.1-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:c46767e8df1b7beefb0899c4a95fb43058fa8500b6db144f4ff3ca38eb2f6393"},
+    {file = "black-23.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50254ebfa56aa46a9fdd5d651f9637485068a1adf42270148cd101cdf56e0ad9"},
+    {file = "black-23.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:403397c033adbc45c2bd41747da1f7fc7eaa44efbee256b53842470d4ac5a70f"},
+    {file = "black-23.9.1-py3-none-any.whl", hash = "sha256:6ccd59584cc834b6d127628713e4b6b968e5f79572da66284532525a042549f9"},
+    {file = "black-23.9.1.tar.gz", hash = "sha256:24b6b3ff5c6d9ea08a8888f6977eae858e1f340d7260cf56d70a49823236b62d"},
 ]
 
 [package.dependencies]
@@ -179,7 +179,7 @@ packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -657,37 +657,19 @@ files = [
 
 [[package]]
 name = "filelock"
-version = "3.12.3"
+version = "3.12.4"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.12.3-py3-none-any.whl", hash = "sha256:f067e40ccc40f2b48395a80fcbd4728262fab54e232e090a4063ab804179efeb"},
-    {file = "filelock-3.12.3.tar.gz", hash = "sha256:0ecc1dd2ec4672a10c8550a8182f1bd0c0a5088470ecd5a125e45f49472fac3d"},
+    {file = "filelock-3.12.4-py3-none-any.whl", hash = "sha256:08c21d87ded6e2b9da6728c3dff51baf1dcecf973b768ef35bcbc3447edb9ad4"},
+    {file = "filelock-3.12.4.tar.gz", hash = "sha256:2e6f249f1f3654291606e046b09f1fd5eac39b360664c27f5aad072012f8bcbd"},
 ]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.7.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["furo (>=2023.7.26)", "sphinx (>=7.1.2)", "sphinx-autodoc-typehints (>=1.24)"]
 testing = ["covdefaults (>=2.3)", "coverage (>=7.3)", "diff-cover (>=7.7)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)", "pytest-timeout (>=2.1)"]
-
-[[package]]
-name = "flake8"
-version = "3.9.2"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-files = [
-    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
-    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
-]
-
-[package.dependencies]
-mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.7.0,<2.8.0"
-pyflakes = ">=2.3.0,<2.4.0"
+typing = ["typing-extensions (>=4.7.1)"]
 
 [[package]]
 name = "furo"
@@ -788,23 +770,6 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
-
-[[package]]
-name = "isort"
-version = "5.12.0"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
-    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.3)"]
-pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
-plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "jaraco-classes"
@@ -999,17 +964,6 @@ files = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.6.1"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = "*"
-files = [
-    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
-    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
-]
-
-[[package]]
 name = "mdit-py-plugins"
 version = "0.3.5"
 description = "Collection of plugins for markdown-it-py"
@@ -1175,71 +1129,71 @@ tox-to-nox = ["jinja2", "tox"]
 
 [[package]]
 name = "orjson"
-version = "3.9.5"
+version = "3.9.7"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "orjson-3.9.5-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:ad6845912a71adcc65df7c8a7f2155eba2096cf03ad2c061c93857de70d699ad"},
-    {file = "orjson-3.9.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e298e0aacfcc14ef4476c3f409e85475031de24e5b23605a465e9bf4b2156273"},
-    {file = "orjson-3.9.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:83c9939073281ef7dd7c5ca7f54cceccb840b440cec4b8a326bda507ff88a0a6"},
-    {file = "orjson-3.9.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e174cc579904a48ee1ea3acb7045e8a6c5d52c17688dfcb00e0e842ec378cabf"},
-    {file = "orjson-3.9.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8d51702f42c785b115401e1d64a27a2ea767ae7cf1fb8edaa09c7cf1571c660"},
-    {file = "orjson-3.9.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f13d61c0c7414ddee1ef4d0f303e2222f8cced5a2e26d9774751aecd72324c9e"},
-    {file = "orjson-3.9.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d748cc48caf5a91c883d306ab648df1b29e16b488c9316852844dd0fd000d1c2"},
-    {file = "orjson-3.9.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bd19bc08fa023e4c2cbf8294ad3f2b8922f4de9ba088dbc71e6b268fdf54591c"},
-    {file = "orjson-3.9.5-cp310-none-win32.whl", hash = "sha256:5793a21a21bf34e1767e3d61a778a25feea8476dcc0bdf0ae1bc506dc34561ea"},
-    {file = "orjson-3.9.5-cp310-none-win_amd64.whl", hash = "sha256:2bcec0b1024d0031ab3eab7a8cb260c8a4e4a5e35993878a2da639d69cdf6a65"},
-    {file = "orjson-3.9.5-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:8547b95ca0e2abd17e1471973e6d676f1d8acedd5f8fb4f739e0612651602d66"},
-    {file = "orjson-3.9.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87ce174d6a38d12b3327f76145acbd26f7bc808b2b458f61e94d83cd0ebb4d76"},
-    {file = "orjson-3.9.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a960bb1bc9a964d16fcc2d4af5a04ce5e4dfddca84e3060c35720d0a062064fe"},
-    {file = "orjson-3.9.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a7aa5573a949760d6161d826d34dc36db6011926f836851fe9ccb55b5a7d8e8"},
-    {file = "orjson-3.9.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b2852afca17d7eea85f8e200d324e38c851c96598ac7b227e4f6c4e59fbd3df"},
-    {file = "orjson-3.9.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa185959c082475288da90f996a82e05e0c437216b96f2a8111caeb1d54ef926"},
-    {file = "orjson-3.9.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:89c9332695b838438ea4b9a482bce8ffbfddde4df92750522d928fb00b7b8dce"},
-    {file = "orjson-3.9.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2493f1351a8f0611bc26e2d3d407efb873032b4f6b8926fed8cfed39210ca4ba"},
-    {file = "orjson-3.9.5-cp311-none-win32.whl", hash = "sha256:ffc544e0e24e9ae69301b9a79df87a971fa5d1c20a6b18dca885699709d01be0"},
-    {file = "orjson-3.9.5-cp311-none-win_amd64.whl", hash = "sha256:89670fe2732e3c0c54406f77cad1765c4c582f67b915c74fda742286809a0cdc"},
-    {file = "orjson-3.9.5-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:15df211469625fa27eced4aa08dc03e35f99c57d45a33855cc35f218ea4071b8"},
-    {file = "orjson-3.9.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9f17c59fe6c02bc5f89ad29edb0253d3059fe8ba64806d789af89a45c35269a"},
-    {file = "orjson-3.9.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca6b96659c7690773d8cebb6115c631f4a259a611788463e9c41e74fa53bf33f"},
-    {file = "orjson-3.9.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a26fafe966e9195b149950334bdbe9026eca17fe8ffe2d8fa87fdc30ca925d30"},
-    {file = "orjson-3.9.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9006b1eb645ecf460da067e2dd17768ccbb8f39b01815a571bfcfab7e8da5e52"},
-    {file = "orjson-3.9.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebfdbf695734b1785e792a1315e41835ddf2a3e907ca0e1c87a53f23006ce01d"},
-    {file = "orjson-3.9.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:4a3943234342ab37d9ed78fb0a8f81cd4b9532f67bf2ac0d3aa45fa3f0a339f3"},
-    {file = "orjson-3.9.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e6762755470b5c82f07b96b934af32e4d77395a11768b964aaa5eb092817bc31"},
-    {file = "orjson-3.9.5-cp312-none-win_amd64.whl", hash = "sha256:c74df28749c076fd6e2157190df23d43d42b2c83e09d79b51694ee7315374ad5"},
-    {file = "orjson-3.9.5-cp37-cp37m-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:88e18a74d916b74f00d0978d84e365c6bf0e7ab846792efa15756b5fb2f7d49d"},
-    {file = "orjson-3.9.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d28514b5b6dfaf69097be70d0cf4f1407ec29d0f93e0b4131bf9cc8fd3f3e374"},
-    {file = "orjson-3.9.5-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b81aca8c7be61e2566246b6a0ca49f8aece70dd3f38c7f5c837f398c4cb142"},
-    {file = "orjson-3.9.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:385c1c713b1e47fd92e96cf55fd88650ac6dfa0b997e8aa7ecffd8b5865078b1"},
-    {file = "orjson-3.9.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f9850c03a8e42fba1a508466e6a0f99472fd2b4a5f30235ea49b2a1b32c04c11"},
-    {file = "orjson-3.9.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4449f84bbb13bcef493d8aa669feadfced0f7c5eea2d0d88b5cc21f812183af8"},
-    {file = "orjson-3.9.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:86127bf194f3b873135e44ce5dc9212cb152b7e06798d5667a898a00f0519be4"},
-    {file = "orjson-3.9.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:0abcd039f05ae9ab5b0ff11624d0b9e54376253b7d3217a358d09c3edf1d36f7"},
-    {file = "orjson-3.9.5-cp37-none-win32.whl", hash = "sha256:10cc8ad5ff7188efcb4bec196009d61ce525a4e09488e6d5db41218c7fe4f001"},
-    {file = "orjson-3.9.5-cp37-none-win_amd64.whl", hash = "sha256:ff27e98532cb87379d1a585837d59b187907228268e7b0a87abe122b2be6968e"},
-    {file = "orjson-3.9.5-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:5bfa79916ef5fef75ad1f377e54a167f0de334c1fa4ebb8d0224075f3ec3d8c0"},
-    {file = "orjson-3.9.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e87dfa6ac0dae764371ab19b35eaaa46dfcb6ef2545dfca03064f21f5d08239f"},
-    {file = "orjson-3.9.5-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:50ced24a7b23058b469ecdb96e36607fc611cbaee38b58e62a55c80d1b3ad4e1"},
-    {file = "orjson-3.9.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b1b74ea2a3064e1375da87788897935832e806cc784de3e789fd3c4ab8eb3fa5"},
-    {file = "orjson-3.9.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a7cb961efe013606913d05609f014ad43edfaced82a576e8b520a5574ce3b2b9"},
-    {file = "orjson-3.9.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1225d2d5ee76a786bda02f8c5e15017462f8432bb960de13d7c2619dba6f0275"},
-    {file = "orjson-3.9.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f39f4b99199df05c7ecdd006086259ed25886cdbd7b14c8cdb10c7675cfcca7d"},
-    {file = "orjson-3.9.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a461dc9fb60cac44f2d3218c36a0c1c01132314839a0e229d7fb1bba69b810d8"},
-    {file = "orjson-3.9.5-cp38-none-win32.whl", hash = "sha256:dedf1a6173748202df223aea29de814b5836732a176b33501375c66f6ab7d822"},
-    {file = "orjson-3.9.5-cp38-none-win_amd64.whl", hash = "sha256:fa504082f53efcbacb9087cc8676c163237beb6e999d43e72acb4bb6f0db11e6"},
-    {file = "orjson-3.9.5-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:6900f0248edc1bec2a2a3095a78a7e3ef4e63f60f8ddc583687eed162eedfd69"},
-    {file = "orjson-3.9.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:17404333c40047888ac40bd8c4d49752a787e0a946e728a4e5723f111b6e55a5"},
-    {file = "orjson-3.9.5-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0eefb7cfdd9c2bc65f19f974a5d1dfecbac711dae91ed635820c6b12da7a3c11"},
-    {file = "orjson-3.9.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:68c78b2a3718892dc018adbc62e8bab6ef3c0d811816d21e6973dee0ca30c152"},
-    {file = "orjson-3.9.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:591ad7d9e4a9f9b104486ad5d88658c79ba29b66c5557ef9edf8ca877a3f8d11"},
-    {file = "orjson-3.9.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6cc2cbf302fbb2d0b2c3c142a663d028873232a434d89ce1b2604ebe5cc93ce8"},
-    {file = "orjson-3.9.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b26b5aa5e9ee1bad2795b925b3adb1b1b34122cb977f30d89e0a1b3f24d18450"},
-    {file = "orjson-3.9.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ef84724f7d29dcfe3aafb1fc5fc7788dca63e8ae626bb9298022866146091a3e"},
-    {file = "orjson-3.9.5-cp39-none-win32.whl", hash = "sha256:664cff27f85939059472afd39acff152fbac9a091b7137092cb651cf5f7747b5"},
-    {file = "orjson-3.9.5-cp39-none-win_amd64.whl", hash = "sha256:91dda66755795ac6100e303e206b636568d42ac83c156547634256a2e68de694"},
-    {file = "orjson-3.9.5.tar.gz", hash = "sha256:6daf5ee0b3cf530b9978cdbf71024f1c16ed4a67d05f6ec435c6e7fe7a52724c"},
+    {file = "orjson-3.9.7-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:b6df858e37c321cefbf27fe7ece30a950bcc3a75618a804a0dcef7ed9dd9c92d"},
+    {file = "orjson-3.9.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5198633137780d78b86bb54dafaaa9baea698b4f059456cd4554ab7009619221"},
+    {file = "orjson-3.9.7-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e736815b30f7e3c9044ec06a98ee59e217a833227e10eb157f44071faddd7c5"},
+    {file = "orjson-3.9.7-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a19e4074bc98793458b4b3ba35a9a1d132179345e60e152a1bb48c538ab863c4"},
+    {file = "orjson-3.9.7-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80acafe396ab689a326ab0d80f8cc61dec0dd2c5dca5b4b3825e7b1e0132c101"},
+    {file = "orjson-3.9.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:355efdbbf0cecc3bd9b12589b8f8e9f03c813a115efa53f8dc2a523bfdb01334"},
+    {file = "orjson-3.9.7-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3aab72d2cef7f1dd6104c89b0b4d6b416b0db5ca87cc2fac5f79c5601f549cc2"},
+    {file = "orjson-3.9.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:36b1df2e4095368ee388190687cb1b8557c67bc38400a942a1a77713580b50ae"},
+    {file = "orjson-3.9.7-cp310-none-win32.whl", hash = "sha256:e94b7b31aa0d65f5b7c72dd8f8227dbd3e30354b99e7a9af096d967a77f2a580"},
+    {file = "orjson-3.9.7-cp310-none-win_amd64.whl", hash = "sha256:82720ab0cf5bb436bbd97a319ac529aee06077ff7e61cab57cee04a596c4f9b4"},
+    {file = "orjson-3.9.7-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:1f8b47650f90e298b78ecf4df003f66f54acdba6a0f763cc4df1eab048fe3738"},
+    {file = "orjson-3.9.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f738fee63eb263530efd4d2e9c76316c1f47b3bbf38c1bf45ae9625feed0395e"},
+    {file = "orjson-3.9.7-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38e34c3a21ed41a7dbd5349e24c3725be5416641fdeedf8f56fcbab6d981c900"},
+    {file = "orjson-3.9.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21a3344163be3b2c7e22cef14fa5abe957a892b2ea0525ee86ad8186921b6cf0"},
+    {file = "orjson-3.9.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:23be6b22aab83f440b62a6f5975bcabeecb672bc627face6a83bc7aeb495dc7e"},
+    {file = "orjson-3.9.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5205ec0dfab1887dd383597012199f5175035e782cdb013c542187d280ca443"},
+    {file = "orjson-3.9.7-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8769806ea0b45d7bf75cad253fba9ac6700b7050ebb19337ff6b4e9060f963fa"},
+    {file = "orjson-3.9.7-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f9e01239abea2f52a429fe9d95c96df95f078f0172489d691b4a848ace54a476"},
+    {file = "orjson-3.9.7-cp311-none-win32.whl", hash = "sha256:8bdb6c911dae5fbf110fe4f5cba578437526334df381b3554b6ab7f626e5eeca"},
+    {file = "orjson-3.9.7-cp311-none-win_amd64.whl", hash = "sha256:9d62c583b5110e6a5cf5169ab616aa4ec71f2c0c30f833306f9e378cf51b6c86"},
+    {file = "orjson-3.9.7-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:1c3cee5c23979deb8d1b82dc4cc49be59cccc0547999dbe9adb434bb7af11cf7"},
+    {file = "orjson-3.9.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a347d7b43cb609e780ff8d7b3107d4bcb5b6fd09c2702aa7bdf52f15ed09fa09"},
+    {file = "orjson-3.9.7-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:154fd67216c2ca38a2edb4089584504fbb6c0694b518b9020ad35ecc97252bb9"},
+    {file = "orjson-3.9.7-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ea3e63e61b4b0beeb08508458bdff2daca7a321468d3c4b320a758a2f554d31"},
+    {file = "orjson-3.9.7-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1eb0b0b2476f357eb2975ff040ef23978137aa674cd86204cfd15d2d17318588"},
+    {file = "orjson-3.9.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b9a20a03576c6b7022926f614ac5a6b0914486825eac89196adf3267c6489d"},
+    {file = "orjson-3.9.7-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:915e22c93e7b7b636240c5a79da5f6e4e84988d699656c8e27f2ac4c95b8dcc0"},
+    {file = "orjson-3.9.7-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f26fb3e8e3e2ee405c947ff44a3e384e8fa1843bc35830fe6f3d9a95a1147b6e"},
+    {file = "orjson-3.9.7-cp312-none-win_amd64.whl", hash = "sha256:d8692948cada6ee21f33db5e23460f71c8010d6dfcfe293c9b96737600a7df78"},
+    {file = "orjson-3.9.7-cp37-cp37m-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:7bab596678d29ad969a524823c4e828929a90c09e91cc438e0ad79b37ce41166"},
+    {file = "orjson-3.9.7-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63ef3d371ea0b7239ace284cab9cd00d9c92b73119a7c274b437adb09bda35e6"},
+    {file = "orjson-3.9.7-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2f8fcf696bbbc584c0c7ed4adb92fd2ad7d153a50258842787bc1524e50d7081"},
+    {file = "orjson-3.9.7-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:90fe73a1f0321265126cbba13677dcceb367d926c7a65807bd80916af4c17047"},
+    {file = "orjson-3.9.7-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:45a47f41b6c3beeb31ac5cf0ff7524987cfcce0a10c43156eb3ee8d92d92bf22"},
+    {file = "orjson-3.9.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a2937f528c84e64be20cb80e70cea76a6dfb74b628a04dab130679d4454395c"},
+    {file = "orjson-3.9.7-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b4fb306c96e04c5863d52ba8d65137917a3d999059c11e659eba7b75a69167bd"},
+    {file = "orjson-3.9.7-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:410aa9d34ad1089898f3db461b7b744d0efcf9252a9415bbdf23540d4f67589f"},
+    {file = "orjson-3.9.7-cp37-none-win32.whl", hash = "sha256:26ffb398de58247ff7bde895fe30817a036f967b0ad0e1cf2b54bda5f8dcfdd9"},
+    {file = "orjson-3.9.7-cp37-none-win_amd64.whl", hash = "sha256:bcb9a60ed2101af2af450318cd89c6b8313e9f8df4e8fb12b657b2e97227cf08"},
+    {file = "orjson-3.9.7-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:5da9032dac184b2ae2da4bce423edff7db34bfd936ebd7d4207ea45840f03905"},
+    {file = "orjson-3.9.7-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7951af8f2998045c656ba8062e8edf5e83fd82b912534ab1de1345de08a41d2b"},
+    {file = "orjson-3.9.7-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b8e59650292aa3a8ea78073fc84184538783966528e442a1b9ed653aa282edcf"},
+    {file = "orjson-3.9.7-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9274ba499e7dfb8a651ee876d80386b481336d3868cba29af839370514e4dce0"},
+    {file = "orjson-3.9.7-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ca1706e8b8b565e934c142db6a9592e6401dc430e4b067a97781a997070c5378"},
+    {file = "orjson-3.9.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83cc275cf6dcb1a248e1876cdefd3f9b5f01063854acdfd687ec360cd3c9712a"},
+    {file = "orjson-3.9.7-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:11c10f31f2c2056585f89d8229a56013bc2fe5de51e095ebc71868d070a8dd81"},
+    {file = "orjson-3.9.7-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:cf334ce1d2fadd1bf3e5e9bf15e58e0c42b26eb6590875ce65bd877d917a58aa"},
+    {file = "orjson-3.9.7-cp38-none-win32.whl", hash = "sha256:76a0fc023910d8a8ab64daed8d31d608446d2d77c6474b616b34537aa7b79c7f"},
+    {file = "orjson-3.9.7-cp38-none-win_amd64.whl", hash = "sha256:7a34a199d89d82d1897fd4a47820eb50947eec9cda5fd73f4578ff692a912f89"},
+    {file = "orjson-3.9.7-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e7e7f44e091b93eb39db88bb0cb765db09b7a7f64aea2f35e7d86cbf47046c65"},
+    {file = "orjson-3.9.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d647b2a9c45a23a84c3e70e19d120011cba5f56131d185c1b78685457320bb"},
+    {file = "orjson-3.9.7-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0eb850a87e900a9c484150c414e21af53a6125a13f6e378cf4cc11ae86c8f9c5"},
+    {file = "orjson-3.9.7-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f4b0042d8388ac85b8330b65406c84c3229420a05068445c13ca28cc222f1f7"},
+    {file = "orjson-3.9.7-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd3e7aae977c723cc1dbb82f97babdb5e5fbce109630fbabb2ea5053523c89d3"},
+    {file = "orjson-3.9.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c616b796358a70b1f675a24628e4823b67d9e376df2703e893da58247458956"},
+    {file = "orjson-3.9.7-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c3ba725cf5cf87d2d2d988d39c6a2a8b6fc983d78ff71bc728b0be54c869c884"},
+    {file = "orjson-3.9.7-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4891d4c934f88b6c29b56395dfc7014ebf7e10b9e22ffd9877784e16c6b2064f"},
+    {file = "orjson-3.9.7-cp39-none-win32.whl", hash = "sha256:14d3fb6cd1040a4a4a530b28e8085131ed94ebc90d72793c59a713de34b60838"},
+    {file = "orjson-3.9.7-cp39-none-win_amd64.whl", hash = "sha256:9ef82157bbcecd75d6296d5d8b2d792242afcd064eb1ac573f8847b52e58f677"},
+    {file = "orjson-3.9.7.tar.gz", hash = "sha256:85e39198f78e2f7e054d296395f6c96f5e02892337746ef5b6a1bf3ed5910142"},
 ]
 
 [[package]]
@@ -1277,67 +1231,65 @@ files = [
 
 [[package]]
 name = "pillow"
-version = "10.0.0"
+version = "10.0.1"
 description = "Python Imaging Library (Fork)"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "Pillow-10.0.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1f62406a884ae75fb2f818694469519fb685cc7eaff05d3451a9ebe55c646891"},
-    {file = "Pillow-10.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d5db32e2a6ccbb3d34d87c87b432959e0db29755727afb37290e10f6e8e62614"},
-    {file = "Pillow-10.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edf4392b77bdc81f36e92d3a07a5cd072f90253197f4a52a55a8cec48a12483b"},
-    {file = "Pillow-10.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:520f2a520dc040512699f20fa1c363eed506e94248d71f85412b625026f6142c"},
-    {file = "Pillow-10.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:8c11160913e3dd06c8ffdb5f233a4f254cb449f4dfc0f8f4549eda9e542c93d1"},
-    {file = "Pillow-10.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a74ba0c356aaa3bb8e3eb79606a87669e7ec6444be352870623025d75a14a2bf"},
-    {file = "Pillow-10.0.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d5d0dae4cfd56969d23d94dc8e89fb6a217be461c69090768227beb8ed28c0a3"},
-    {file = "Pillow-10.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:22c10cc517668d44b211717fd9775799ccec4124b9a7f7b3635fc5386e584992"},
-    {file = "Pillow-10.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:dffe31a7f47b603318c609f378ebcd57f1554a3a6a8effbc59c3c69f804296de"},
-    {file = "Pillow-10.0.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:9fb218c8a12e51d7ead2a7c9e101a04982237d4855716af2e9499306728fb485"},
-    {file = "Pillow-10.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d35e3c8d9b1268cbf5d3670285feb3528f6680420eafe35cccc686b73c1e330f"},
-    {file = "Pillow-10.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ed64f9ca2f0a95411e88a4efbd7a29e5ce2cea36072c53dd9d26d9c76f753b3"},
-    {file = "Pillow-10.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b6eb5502f45a60a3f411c63187db83a3d3107887ad0d036c13ce836f8a36f1d"},
-    {file = "Pillow-10.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c1fbe7621c167ecaa38ad29643d77a9ce7311583761abf7836e1510c580bf3dd"},
-    {file = "Pillow-10.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:cd25d2a9d2b36fcb318882481367956d2cf91329f6892fe5d385c346c0649629"},
-    {file = "Pillow-10.0.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:3b08d4cc24f471b2c8ca24ec060abf4bebc6b144cb89cba638c720546b1cf538"},
-    {file = "Pillow-10.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d737a602fbd82afd892ca746392401b634e278cb65d55c4b7a8f48e9ef8d008d"},
-    {file = "Pillow-10.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:3a82c40d706d9aa9734289740ce26460a11aeec2d9c79b7af87bb35f0073c12f"},
-    {file = "Pillow-10.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:bc2ec7c7b5d66b8ec9ce9f720dbb5fa4bace0f545acd34870eff4a369b44bf37"},
-    {file = "Pillow-10.0.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:d80cf684b541685fccdd84c485b31ce73fc5c9b5d7523bf1394ce134a60c6883"},
-    {file = "Pillow-10.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:76de421f9c326da8f43d690110f0e79fe3ad1e54be811545d7d91898b4c8493e"},
-    {file = "Pillow-10.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81ff539a12457809666fef6624684c008e00ff6bf455b4b89fd00a140eecd640"},
-    {file = "Pillow-10.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce543ed15570eedbb85df19b0a1a7314a9c8141a36ce089c0a894adbfccb4568"},
-    {file = "Pillow-10.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:685ac03cc4ed5ebc15ad5c23bc555d68a87777586d970c2c3e216619a5476223"},
-    {file = "Pillow-10.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d72e2ecc68a942e8cf9739619b7f408cc7b272b279b56b2c83c6123fcfa5cdff"},
-    {file = "Pillow-10.0.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d50b6aec14bc737742ca96e85d6d0a5f9bfbded018264b3b70ff9d8c33485551"},
-    {file = "Pillow-10.0.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:00e65f5e822decd501e374b0650146063fbb30a7264b4d2744bdd7b913e0cab5"},
-    {file = "Pillow-10.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:f31f9fdbfecb042d046f9d91270a0ba28368a723302786c0009ee9b9f1f60199"},
-    {file = "Pillow-10.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:1ce91b6ec08d866b14413d3f0bbdea7e24dfdc8e59f562bb77bc3fe60b6144ca"},
-    {file = "Pillow-10.0.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:349930d6e9c685c089284b013478d6f76e3a534e36ddfa912cde493f235372f3"},
-    {file = "Pillow-10.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3a684105f7c32488f7153905a4e3015a3b6c7182e106fe3c37fbb5ef3e6994c3"},
-    {file = "Pillow-10.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4f69b3700201b80bb82c3a97d5e9254084f6dd5fb5b16fc1a7b974260f89f43"},
-    {file = "Pillow-10.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f07ea8d2f827d7d2a49ecf1639ec02d75ffd1b88dcc5b3a61bbb37a8759ad8d"},
-    {file = "Pillow-10.0.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:040586f7d37b34547153fa383f7f9aed68b738992380ac911447bb78f2abe530"},
-    {file = "Pillow-10.0.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:f88a0b92277de8e3ca715a0d79d68dc82807457dae3ab8699c758f07c20b3c51"},
-    {file = "Pillow-10.0.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:c7cf14a27b0d6adfaebb3ae4153f1e516df54e47e42dcc073d7b3d76111a8d86"},
-    {file = "Pillow-10.0.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3400aae60685b06bb96f99a21e1ada7bc7a413d5f49bce739828ecd9391bb8f7"},
-    {file = "Pillow-10.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:dbc02381779d412145331789b40cc7b11fdf449e5d94f6bc0b080db0a56ea3f0"},
-    {file = "Pillow-10.0.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:9211e7ad69d7c9401cfc0e23d49b69ca65ddd898976d660a2fa5904e3d7a9baa"},
-    {file = "Pillow-10.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:faaf07ea35355b01a35cb442dd950d8f1bb5b040a7787791a535de13db15ed90"},
-    {file = "Pillow-10.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9f72a021fbb792ce98306ffb0c348b3c9cb967dce0f12a49aa4c3d3fdefa967"},
-    {file = "Pillow-10.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f7c16705f44e0504a3a2a14197c1f0b32a95731d251777dcb060aa83022cb2d"},
-    {file = "Pillow-10.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:76edb0a1fa2b4745fb0c99fb9fb98f8b180a1bbceb8be49b087e0b21867e77d3"},
-    {file = "Pillow-10.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:368ab3dfb5f49e312231b6f27b8820c823652b7cd29cfbd34090565a015e99ba"},
-    {file = "Pillow-10.0.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:608bfdee0d57cf297d32bcbb3c728dc1da0907519d1784962c5f0c68bb93e5a3"},
-    {file = "Pillow-10.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5c6e3df6bdd396749bafd45314871b3d0af81ff935b2d188385e970052091017"},
-    {file = "Pillow-10.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:7be600823e4c8631b74e4a0d38384c73f680e6105a7d3c6824fcf226c178c7e6"},
-    {file = "Pillow-10.0.0-pp310-pypy310_pp73-macosx_10_10_x86_64.whl", hash = "sha256:92be919bbc9f7d09f7ae343c38f5bb21c973d2576c1d45600fce4b74bafa7ac0"},
-    {file = "Pillow-10.0.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8182b523b2289f7c415f589118228d30ac8c355baa2f3194ced084dac2dbba"},
-    {file = "Pillow-10.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:38250a349b6b390ee6047a62c086d3817ac69022c127f8a5dc058c31ccef17f3"},
-    {file = "Pillow-10.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:88af2003543cc40c80f6fca01411892ec52b11021b3dc22ec3bc9d5afd1c5334"},
-    {file = "Pillow-10.0.0-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:c189af0545965fa8d3b9613cfdb0cd37f9d71349e0f7750e1fd704648d475ed2"},
-    {file = "Pillow-10.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce7b031a6fc11365970e6a5686d7ba8c63e4c1cf1ea143811acbb524295eabed"},
-    {file = "Pillow-10.0.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:db24668940f82321e746773a4bc617bfac06ec831e5c88b643f91f122a785684"},
-    {file = "Pillow-10.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:efe8c0681042536e0d06c11f48cebe759707c9e9abf880ee213541c5b46c5bf3"},
-    {file = "Pillow-10.0.0.tar.gz", hash = "sha256:9c82b5b3e043c7af0d95792d0d20ccf68f61a1fec6b3530e718b688422727396"},
+    {file = "Pillow-10.0.1-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:8f06be50669087250f319b706decf69ca71fdecd829091a37cc89398ca4dc17a"},
+    {file = "Pillow-10.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:50bd5f1ebafe9362ad622072a1d2f5850ecfa44303531ff14353a4059113b12d"},
+    {file = "Pillow-10.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6a90167bcca1216606223a05e2cf991bb25b14695c518bc65639463d7db722d"},
+    {file = "Pillow-10.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f11c9102c56ffb9ca87134bd025a43d2aba3f1155f508eff88f694b33a9c6d19"},
+    {file = "Pillow-10.0.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:186f7e04248103482ea6354af6d5bcedb62941ee08f7f788a1c7707bc720c66f"},
+    {file = "Pillow-10.0.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0462b1496505a3462d0f35dc1c4d7b54069747d65d00ef48e736acda2c8cbdff"},
+    {file = "Pillow-10.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d889b53ae2f030f756e61a7bff13684dcd77e9af8b10c6048fb2c559d6ed6eaf"},
+    {file = "Pillow-10.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:552912dbca585b74d75279a7570dd29fa43b6d93594abb494ebb31ac19ace6bd"},
+    {file = "Pillow-10.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:787bb0169d2385a798888e1122c980c6eff26bf941a8ea79747d35d8f9210ca0"},
+    {file = "Pillow-10.0.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:fd2a5403a75b54661182b75ec6132437a181209b901446ee5724b589af8edef1"},
+    {file = "Pillow-10.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2d7e91b4379f7a76b31c2dda84ab9e20c6220488e50f7822e59dac36b0cd92b1"},
+    {file = "Pillow-10.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19e9adb3f22d4c416e7cd79b01375b17159d6990003633ff1d8377e21b7f1b21"},
+    {file = "Pillow-10.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93139acd8109edcdeffd85e3af8ae7d88b258b3a1e13a038f542b79b6d255c54"},
+    {file = "Pillow-10.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:92a23b0431941a33242b1f0ce6c88a952e09feeea9af4e8be48236a68ffe2205"},
+    {file = "Pillow-10.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:cbe68deb8580462ca0d9eb56a81912f59eb4542e1ef8f987405e35a0179f4ea2"},
+    {file = "Pillow-10.0.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:522ff4ac3aaf839242c6f4e5b406634bfea002469656ae8358644fc6c4856a3b"},
+    {file = "Pillow-10.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:84efb46e8d881bb06b35d1d541aa87f574b58e87f781cbba8d200daa835b42e1"},
+    {file = "Pillow-10.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:898f1d306298ff40dc1b9ca24824f0488f6f039bc0e25cfb549d3195ffa17088"},
+    {file = "Pillow-10.0.1-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:bcf1207e2f2385a576832af02702de104be71301c2696d0012b1b93fe34aaa5b"},
+    {file = "Pillow-10.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5d6c9049c6274c1bb565021367431ad04481ebb54872edecfcd6088d27edd6ed"},
+    {file = "Pillow-10.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28444cb6ad49726127d6b340217f0627abc8732f1194fd5352dec5e6a0105635"},
+    {file = "Pillow-10.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de596695a75496deb3b499c8c4f8e60376e0516e1a774e7bc046f0f48cd620ad"},
+    {file = "Pillow-10.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2872f2d7846cf39b3dbff64bc1104cc48c76145854256451d33c5faa55c04d1a"},
+    {file = "Pillow-10.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ce90f8a24e1c15465048959f1e94309dfef93af272633e8f37361b824532e91"},
+    {file = "Pillow-10.0.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ee7810cf7c83fa227ba9125de6084e5e8b08c59038a7b2c9045ef4dde61663b4"},
+    {file = "Pillow-10.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:b1be1c872b9b5fcc229adeadbeb51422a9633abd847c0ff87dc4ef9bb184ae08"},
+    {file = "Pillow-10.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:98533fd7fa764e5f85eebe56c8e4094db912ccbe6fbf3a58778d543cadd0db08"},
+    {file = "Pillow-10.0.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:764d2c0daf9c4d40ad12fbc0abd5da3af7f8aa11daf87e4fa1b834000f4b6b0a"},
+    {file = "Pillow-10.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fcb59711009b0168d6ee0bd8fb5eb259c4ab1717b2f538bbf36bacf207ef7a68"},
+    {file = "Pillow-10.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:697a06bdcedd473b35e50a7e7506b1d8ceb832dc238a336bd6f4f5aa91a4b500"},
+    {file = "Pillow-10.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f665d1e6474af9f9da5e86c2a3a2d2d6204e04d5af9c06b9d42afa6ebde3f21"},
+    {file = "Pillow-10.0.1-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:2fa6dd2661838c66f1a5473f3b49ab610c98a128fc08afbe81b91a1f0bf8c51d"},
+    {file = "Pillow-10.0.1-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:3a04359f308ebee571a3127fdb1bd01f88ba6f6fb6d087f8dd2e0d9bff43f2a7"},
+    {file = "Pillow-10.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:723bd25051454cea9990203405fa6b74e043ea76d4968166dfd2569b0210886a"},
+    {file = "Pillow-10.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:71671503e3015da1b50bd18951e2f9daf5b6ffe36d16f1eb2c45711a301521a7"},
+    {file = "Pillow-10.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:44e7e4587392953e5e251190a964675f61e4dae88d1e6edbe9f36d6243547ff3"},
+    {file = "Pillow-10.0.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:3855447d98cced8670aaa63683808df905e956f00348732448b5a6df67ee5849"},
+    {file = "Pillow-10.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ed2d9c0704f2dc4fa980b99d565c0c9a543fe5101c25b3d60488b8ba80f0cce1"},
+    {file = "Pillow-10.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5bb289bb835f9fe1a1e9300d011eef4d69661bb9b34d5e196e5e82c4cb09b37"},
+    {file = "Pillow-10.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a0d3e54ab1df9df51b914b2233cf779a5a10dfd1ce339d0421748232cea9876"},
+    {file = "Pillow-10.0.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:2cc6b86ece42a11f16f55fe8903595eff2b25e0358dec635d0a701ac9586588f"},
+    {file = "Pillow-10.0.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:ca26ba5767888c84bf5a0c1a32f069e8204ce8c21d00a49c90dabeba00ce0145"},
+    {file = "Pillow-10.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f0b4b06da13275bc02adfeb82643c4a6385bd08d26f03068c2796f60d125f6f2"},
+    {file = "Pillow-10.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bc2e3069569ea9dbe88d6b8ea38f439a6aad8f6e7a6283a38edf61ddefb3a9bf"},
+    {file = "Pillow-10.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:8b451d6ead6e3500b6ce5c7916a43d8d8d25ad74b9102a629baccc0808c54971"},
+    {file = "Pillow-10.0.1-pp310-pypy310_pp73-macosx_10_10_x86_64.whl", hash = "sha256:32bec7423cdf25c9038fef614a853c9d25c07590e1a870ed471f47fb80b244db"},
+    {file = "Pillow-10.0.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7cf63d2c6928b51d35dfdbda6f2c1fddbe51a6bc4a9d4ee6ea0e11670dd981e"},
+    {file = "Pillow-10.0.1-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f6d3d4c905e26354e8f9d82548475c46d8e0889538cb0657aa9c6f0872a37aa4"},
+    {file = "Pillow-10.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:847e8d1017c741c735d3cd1883fa7b03ded4f825a6e5fcb9378fd813edee995f"},
+    {file = "Pillow-10.0.1-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:7f771e7219ff04b79e231d099c0a28ed83aa82af91fd5fa9fdb28f5b8d5addaf"},
+    {file = "Pillow-10.0.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:459307cacdd4138edee3875bbe22a2492519e060660eaf378ba3b405d1c66317"},
+    {file = "Pillow-10.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b059ac2c4c7a97daafa7dc850b43b2d3667def858a4f112d1aa082e5c3d6cf7d"},
+    {file = "Pillow-10.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d6caf3cd38449ec3cd8a68b375e0c6fe4b6fd04edb6c9766b55ef84a6e8ddf2d"},
+    {file = "Pillow-10.0.1.tar.gz", hash = "sha256:d72967b06be9300fed5cfbc8b5bafceec48bf7cdc7dab66b1d2549035287191d"},
 ]
 
 [package.extras]
@@ -1415,17 +1367,6 @@ files = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.7.0"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
-    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -1487,17 +1428,6 @@ typing-extensions = ">=4.2.0"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
-
-[[package]]
-name = "pyflakes"
-version = "2.3.1"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
-    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
-]
 
 [[package]]
 name = "pygments"
@@ -1595,13 +1525,13 @@ testing = ["Django", "django-configurations (>=2.0)", "six"]
 
 [[package]]
 name = "pytz"
-version = "2023.3"
+version = "2023.3.post1"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
-    {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
+    {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
+    {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
 ]
 
 [[package]]
@@ -1760,6 +1690,32 @@ rawhtmlsupport = ["xhtml2pdf"]
 sphinx = ["sphinx"]
 svgsupport = ["svglib"]
 tests = ["pyPdf2", "pymupdf"]
+
+[[package]]
+name = "ruff"
+version = "0.0.290"
+description = "An extremely fast Python linter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.0.290-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:0e2b09ac4213b11a3520221083866a5816616f3ae9da123037b8ab275066fbac"},
+    {file = "ruff-0.0.290-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:4ca6285aa77b3d966be32c9a3cd531655b3d4a0171e1f9bf26d66d0372186767"},
+    {file = "ruff-0.0.290-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35e3550d1d9f2157b0fcc77670f7bb59154f223bff281766e61bdd1dd854e0c5"},
+    {file = "ruff-0.0.290-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d748c8bd97874f5751aed73e8dde379ce32d16338123d07c18b25c9a2796574a"},
+    {file = "ruff-0.0.290-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:982af5ec67cecd099e2ef5e238650407fb40d56304910102d054c109f390bf3c"},
+    {file = "ruff-0.0.290-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bbd37352cea4ee007c48a44c9bc45a21f7ba70a57edfe46842e346651e2b995a"},
+    {file = "ruff-0.0.290-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d9be6351b7889462912e0b8185a260c0219c35dfd920fb490c7f256f1d8313e"},
+    {file = "ruff-0.0.290-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75cdc7fe32dcf33b7cec306707552dda54632ac29402775b9e212a3c16aad5e6"},
+    {file = "ruff-0.0.290-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb07f37f7aecdbbc91d759c0c09870ce0fb3eed4025eebedf9c4b98c69abd527"},
+    {file = "ruff-0.0.290-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2ab41bc0ba359d3f715fc7b705bdeef19c0461351306b70a4e247f836b9350ed"},
+    {file = "ruff-0.0.290-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:150bf8050214cea5b990945b66433bf9a5e0cef395c9bc0f50569e7de7540c86"},
+    {file = "ruff-0.0.290-py3-none-musllinux_1_2_i686.whl", hash = "sha256:75386ebc15fe5467248c039f5bf6a0cfe7bfc619ffbb8cd62406cd8811815fca"},
+    {file = "ruff-0.0.290-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ac93eadf07bc4ab4c48d8bb4e427bf0f58f3a9c578862eb85d99d704669f5da0"},
+    {file = "ruff-0.0.290-py3-none-win32.whl", hash = "sha256:461fbd1fb9ca806d4e3d5c745a30e185f7cf3ca77293cdc17abb2f2a990ad3f7"},
+    {file = "ruff-0.0.290-py3-none-win_amd64.whl", hash = "sha256:f1f49f5ec967fd5778813780b12a5650ab0ebcb9ddcca28d642c689b36920796"},
+    {file = "ruff-0.0.290-py3-none-win_arm64.whl", hash = "sha256:ae5a92dfbdf1f0c689433c223f8dac0782c2b2584bd502dfdbc76475669f1ba1"},
+    {file = "ruff-0.0.290.tar.gz", hash = "sha256:949fecbc5467bb11b8db810a7fa53c7e02633856ee6bd1302b2f43adcd71b88d"},
+]
 
 [[package]]
 name = "secretstorage"
@@ -2051,13 +2007,13 @@ files = [
 
 [[package]]
 name = "types-pytz"
-version = "2023.3.0.1"
+version = "2023.3.1.0"
 description = "Typing stubs for pytz"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-pytz-2023.3.0.1.tar.gz", hash = "sha256:1a7b8d4aac70981cfa24478a41eadfcd96a087c986d6f150d77e3ceb3c2bdfab"},
-    {file = "types_pytz-2023.3.0.1-py3-none-any.whl", hash = "sha256:65152e872137926bb67a8fe6cc9cfd794365df86650c5d5fdc7b167b0f38892e"},
+    {file = "types-pytz-2023.3.1.0.tar.gz", hash = "sha256:8e7d2198cba44a72df7628887c90f68a568e1445f14db64631af50c3cab8c090"},
+    {file = "types_pytz-2023.3.1.0-py3-none-any.whl", hash = "sha256:a660a38ed86d45970603e4f3b4877c7ba947668386a896fb5d9589c17e7b8407"},
 ]
 
 [[package]]
@@ -2126,13 +2082,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.24.4"
+version = "20.24.5"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.24.4-py3-none-any.whl", hash = "sha256:29c70bb9b88510f6414ac3e55c8b413a1f96239b6b789ca123437d5e892190cb"},
-    {file = "virtualenv-20.24.4.tar.gz", hash = "sha256:772b05bfda7ed3b8ecd16021ca9716273ad9f4467c801f27e83ac73430246dca"},
+    {file = "virtualenv-20.24.5-py3-none-any.whl", hash = "sha256:b80039f280f4919c77b30f1c23294ae357c4c8701042086e3fc005963e4e537b"},
+    {file = "virtualenv-20.24.5.tar.gz", hash = "sha256:e8361967f6da6fbdf1426483bfe9fca8287c242ac0bc30429905721cefbff752"},
 ]
 
 [package.dependencies]
@@ -2166,4 +2122,4 @@ minify = ["htmlmin"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "964a3eac9a00cb610e1cad707710c36dc7bc12e3892fa1872ed54ff4b16de0d3"
+content-hash = "78aa68593187bc189b1eb57a4a57ab1d9bfc58f8a737cecfbf23aafa1fe879a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,6 @@ certifi = "^2023.7.22"  # needed for GitHub Actions
 keyring = "24.2.0"  # needed for GitHub Actions
 pytest = "^6"
 black = "*"
-flake8 = "^3"
-isort = "^5"
 mypy = "<1"
 django-stubs = "^1.5.0"
 pytest-django = "^3"
@@ -56,17 +54,76 @@ poethepoet = "^0"
 coverage = {extras = ["toml"], version = "^6"}
 pytest-cov = "^3"
 pytest-benchmark = "^4.0.0"
+ruff = "^0.0.290"
 
-[tool.isort]
-default_section = "THIRDPARTY"
-known_first_party = ["django_unicorn", "example"]
-known_django = "django"
-sections = ["FUTURE", "STDLIB", "DJANGO", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
-lines_after_imports = 2
-multi_line_output = 3
-include_trailing_comma = true
-skip_glob = "*/migrations/*.py"
-profile = "black"
+[tool.black]
+target-version = ["py38", "py39", "py310"]
+line-length = 120
+extend-exclude = "migrations"
+
+[tool.ruff]
+src = ["django_unicorn"]
+exclude = ["example", "**/migrations/*"]
+target-version = "py38"
+line-length = 120
+select = [
+  "A",
+  "ARG",
+  "B",
+  "C",
+  "DTZ",
+  "E",
+  "EM",
+  "F",
+  "FBT",
+  "I",
+  "ICN",
+  "ISC",
+  "N",
+  "PLC",
+  "PLE",
+  "PLR",
+  "PLW",
+  "Q",
+  "RUF",
+  "S",
+  "T",
+  "TID",
+  "UP",
+  "W",
+  "YTT",
+]
+ignore = [
+  # Allow non-abstract empty methods in abstract base classes
+  "B027",
+  # Allow boolean positional values in function calls, like `dict.get(... True)`
+  "FBT003",
+  # Ignore checks for possible passwords
+  "S105", "S106", "S107",
+  # Ignore complexity
+  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+  # Ignore unused variables
+  "F841",
+   # Ignore exception strings
+  "EM101", "EM102",
+]
+unfixable = [
+  # Don't touch unused imports
+  "F401",
+]
+
+[tool.ruff.pydocstyle]
+convention = "google"  # Accepts: "google", "numpy", or "pep257".
+
+[tool.ruff.isort]
+known-first-party = ["django_unicorn", "example"]
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.per-file-ignores]
+# Tests can use magic values, assertions, and relative imports
+"tests/**/*" = ["PLR2004", "S101", "TID252"]
 
 [tool.pytest.ini_options]
 addopts = "--quiet --failed-first --reuse-db --nomigrations -p no:warnings -m 'not slow' --benchmark-skip"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 # This is a temporary solution for the fact that `pip install -e`
 # fails when there is not a `setup.py`.

--- a/tests/call_method_parser/test_parse_args.py
+++ b/tests/call_method_parser/test_parse_args.py
@@ -123,7 +123,7 @@ def test_list_args():
 
 
 def test_datetime():
-    expected = datetime(2020, 9, 12, 1, 1, 1)
+    expected = datetime(2020, 9, 12, 1, 1, 1)  # noqa: DTZ001
     actual = eval_value("2020-09-12T01:01:01")
 
     assert actual == expected

--- a/tests/call_method_parser/test_parse_call_method_name.py
+++ b/tests/call_method_parser/test_parse_call_method_name.py
@@ -1,5 +1,3 @@
-import pytest
-
 from django_unicorn.call_method_parser import parse_call_method_name
 
 
@@ -59,7 +57,7 @@ def test_one_arg():
 
 
 def test_kwargs():
-    expected = ("set_name", tuple(), {"kwarg1": "wow"})
+    expected = ("set_name", (), {"kwarg1": "wow"})
     actual = parse_call_method_name("set_name(kwarg1='wow')")
 
     assert actual == expected
@@ -73,14 +71,14 @@ def test_args_and_kwargs():
 
 
 def test_special_method_without_parens():
-    expected = ("$reset", tuple(), {})
+    expected = ("$reset", (), {})
     actual = parse_call_method_name("$reset")
 
     assert actual == expected
 
 
 def test_special_method_with_parens():
-    expected = ("$reset", tuple(), {})
+    expected = ("$reset", (), {})
     actual = parse_call_method_name("$reset()")
 
     assert actual == expected

--- a/tests/call_method_parser/test_parse_kwarg.py
+++ b/tests/call_method_parser/test_parse_kwarg.py
@@ -1,6 +1,6 @@
 import pytest
 
-from django_unicorn.call_method_parser import InvalidKwarg, parse_kwarg
+from django_unicorn.call_method_parser import InvalidKwargError, parse_kwarg
 
 
 def test_kwargs_string():
@@ -22,38 +22,38 @@ def test_kwargs_int():
 
 
 def test_kwargs_invalid_startswith_doublequote():
-    with pytest.raises(InvalidKwarg) as e:
+    with pytest.raises(InvalidKwargError) as e:
         parse_kwarg('"test"=2')
 
-    assert e.type == InvalidKwarg
+    assert e.type == InvalidKwargError
 
 
 def test_kwargs_invalid_startswith_singlequote():
-    with pytest.raises(InvalidKwarg) as e:
+    with pytest.raises(InvalidKwargError) as e:
         parse_kwarg("'test'=2")
 
-    assert e.type == InvalidKwarg
+    assert e.type == InvalidKwargError
 
 
 def test_kwargs_invalid_no_equal_sign():
-    with pytest.raises(InvalidKwarg) as e:
+    with pytest.raises(InvalidKwargError) as e:
         parse_kwarg("test")
 
-    assert e.type == InvalidKwarg
+    assert e.type == InvalidKwargError
 
 
 def test_kwargs_invalid_internal_doublequote():
-    with pytest.raises(InvalidKwarg) as e:
+    with pytest.raises(InvalidKwargError) as e:
         parse_kwarg('te"st=1')
 
-    assert e.type == InvalidKwarg
+    assert e.type == InvalidKwargError
 
 
 def test_kwargs_invalid_internal_singlequote():
-    with pytest.raises(InvalidKwarg) as e:
+    with pytest.raises(InvalidKwargError) as e:
         parse_kwarg("te'st=1")
 
-    assert e.type == InvalidKwarg
+    assert e.type == InvalidKwargError
 
 
 def test_kwargs_skip_unparseable_value():

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -2,13 +2,13 @@ import types
 
 import orjson
 import pytest
-
-from django_unicorn.components import UnicornView
-from django_unicorn.serializer import InvalidFieldNameError
 from tests.views.fake_components import (
     FakeAuthenticationComponent,
     FakeValidationComponent,
 )
+
+from django_unicorn.components import UnicornView
+from django_unicorn.serializer import InvalidFieldNameError
 
 
 class ExampleComponent(UnicornView):
@@ -84,7 +84,7 @@ def test_get_frontend_context_variables_javascript_exclude(component):
     class Meta:
         javascript_exclude = ("name",)
 
-    setattr(component, "Meta", Meta)
+    component.Meta = Meta
 
     frontend_context_variables = component.get_frontend_context_variables()
     frontend_context_variables_dict = orjson.loads(frontend_context_variables)
@@ -96,7 +96,7 @@ def test_get_frontend_context_variables_javascript_exclude_invalid_field(compone
     class Meta:
         javascript_exclude = ("blob",)
 
-    setattr(component, "Meta", Meta)
+    component.Meta = Meta
 
     with pytest.raises(InvalidFieldNameError):
         component.get_frontend_context_variables()
@@ -110,9 +110,7 @@ def test_get_frontend_context_variables_exclude_field(component):
         class Meta:
             exclude = ("name",)
 
-    component = ExampleComponentWithMetaExclude(
-        component_id="asdf1234", component_name="example"
-    )
+    component = ExampleComponentWithMetaExclude(component_id="asdf1234", component_name="example")
 
     frontend_context_variables = component.get_frontend_context_variables()
     frontend_context_variables_dict = orjson.loads(frontend_context_variables)
@@ -120,7 +118,7 @@ def test_get_frontend_context_variables_exclude_field(component):
     assert "name" not in frontend_context_variables_dict
 
 
-def test_get_frontend_context_variables_exclude_field_invalid_type(component):
+def test_get_frontend_context_variables_exclude_field_invalid_type():
     # Use internal class prevent class cache from causing issues
     class ExampleComponentWithMetaInvalidExclude(UnicornView):
         name = "world"
@@ -129,9 +127,7 @@ def test_get_frontend_context_variables_exclude_field_invalid_type(component):
             exclude = ""
 
     with pytest.raises(AssertionError):
-        ExampleComponentWithMetaInvalidExclude(
-            component_id="asdf1234", component_name="example"
-        )
+        ExampleComponentWithMetaInvalidExclude(component_id="asdf1234", component_name="example")
 
 
 def test_get_frontend_context_variables_exclude_invalid_field():
@@ -143,9 +139,7 @@ def test_get_frontend_context_variables_exclude_invalid_field():
             exclude = ("blob",)
 
     with pytest.raises(InvalidFieldNameError):
-        ExampleComponentWithMetaInvalidExclude(
-            component_id="asdf1234", component_name="example"
-        )
+        ExampleComponentWithMetaInvalidExclude(component_id="asdf1234", component_name="example")
 
 
 def test_get_frontend_context_variables(component):
@@ -157,9 +151,7 @@ def test_get_frontend_context_variables(component):
 
 def test_get_context_data(component):
     context_data = component.get_context_data()
-    assert (
-        len(context_data) == 4
-    )  # `unicorn` and `view` are added to context data by default
+    assert len(context_data) == 4  # `unicorn` and `view` are added to context data by default
     assert context_data.get("name") == "World"
     assert isinstance(context_data.get("get_name"), types.MethodType)
 
@@ -217,11 +209,11 @@ def test_is_public(component):
 
 
 def test_is_public_protected(component):
-    assert component._is_public("_test_name") == False
+    assert component._is_public("_test_name") is False
 
 
 def test_is_public_http_method_names(component):
-    assert component._is_public("http_method_names") == False
+    assert component._is_public("http_method_names") is False
 
 
 def test_meta_javascript_exclude():
@@ -238,7 +230,7 @@ def test_meta_javascript_exclude():
 
 def test_meta_javascript_exclude_nested_with_tuple():
     class TestComponent(UnicornView):
-        name = {"Universe": {"World": "Earth"}}
+        name = {"Universe": {"World": "Earth"}}  # noqa: RUF012
 
         class Meta:
             javascript_exclude = ("name.Universe",)
@@ -250,15 +242,13 @@ def test_meta_javascript_exclude_nested_with_tuple():
 
 def test_meta_javascript_exclude_nested_multiple_with_spaces():
     class TestComponent(UnicornView):
-        name = {"Universe": {"World": "Earth"}}
-        another = {"Neutral Milk Hotel": {"album": {"On Avery Island": 1996}}}
+        name = {"Universe": {"World": "Earth"}}  # noqa: RUF012
+        another = {"Neutral Milk Hotel": {"album": {"On Avery Island": 1996}}}  # noqa: RUF012
 
         class Meta:
             javascript_exclude = ("another.Neutral Milk Hotel.album",)
 
-    expected = (
-        '{"another":{"Neutral Milk Hotel":{}},"name":{"Universe":{"World":"Earth"}}}'
-    )
+    expected = '{"another":{"Neutral Milk Hotel":{}},"name":{"Universe":{"World":"Earth"}}}'
     component = TestComponent(component_id="asdf1234", component_name="hello-world")
     actual = component.get_frontend_context_variables()
     assert expected == actual
@@ -266,10 +256,10 @@ def test_meta_javascript_exclude_nested_multiple_with_spaces():
 
 def test_meta_javascript_exclude_nested_with_list():
     class TestComponent(UnicornView):
-        name = {"Universe": {"World": "Earth"}}
+        name = {"Universe": {"World": "Earth"}}  # noqa: RUF012
 
         class Meta:
-            javascript_exclude = [
+            javascript_exclude = [  # noqa: RUF012
                 "name.Universe",
             ]
 
@@ -296,9 +286,7 @@ def test_get_frontend_context_variables_form_with_boolean_field(component):
     without an explicit fix.
     """
 
-    component = FakeValidationComponent(
-        component_id="asdf1234", component_name="example"
-    )
+    component = FakeValidationComponent(component_id="asdf1234", component_name="example")
 
     frontend_context_variables = component.get_frontend_context_variables()
     frontend_context_variables_dict = orjson.loads(frontend_context_variables)
@@ -312,8 +300,6 @@ def test_get_frontend_context_variables_authentication_form(component):
     init with data as a kwarg.
     """
 
-    component = FakeAuthenticationComponent(
-        component_id="asdf1234", component_name="example"
-    )
+    component = FakeAuthenticationComponent(component_id="asdf1234", component_name="example")
 
     component.get_frontend_context_variables()

--- a/tests/components/test_get_locations.py
+++ b/tests/components/test_get_locations.py
@@ -18,28 +18,28 @@ def clear_apps(settings):
     settings.UNICORN["APPS"] = unicorn_apps
 
 
-def test_get_locations_kebab_case(cache_clear):
+def test_get_locations_kebab_case(cache_clear):  # noqa: ARG001
     expected = [("unicorn.components.hello_world", "HelloWorldView")]
     actual = get_locations("hello-world")
 
     assert expected == actual
 
 
-def test_get_locations_with_slashes(cache_clear):
+def test_get_locations_with_slashes(cache_clear):  # noqa: ARG001
     expected = [("unicorn.components.nested.table", "TableView")]
     actual = get_locations("nested/table")
 
     assert expected == actual
 
 
-def test_get_locations_with_dots(cache_clear):
+def test_get_locations_with_dots(cache_clear):  # noqa: ARG001
     expected = [("nested", "table"), ("unicorn.components.nested.table", "TableView")]
     actual = get_locations("nested.table")
 
     assert expected == actual
 
 
-def test_get_locations_fully_qualified_with_dots(cache_clear):
+def test_get_locations_fully_qualified_with_dots(cache_clear):  # noqa: ARG001
     expected = [
         ("project.components.hello_world", "HelloWorldView"),
     ]
@@ -48,7 +48,7 @@ def test_get_locations_fully_qualified_with_dots(cache_clear):
     assert expected == actual
 
 
-def test_get_locations_fully_qualified_with_slashes(cache_clear):
+def test_get_locations_fully_qualified_with_slashes(cache_clear):  # noqa: ARG001
     expected = [
         ("project.components.hello_world", "HelloWorldView"),
     ]
@@ -57,7 +57,7 @@ def test_get_locations_fully_qualified_with_slashes(cache_clear):
     assert expected == actual
 
 
-def test_get_locations_fully_qualified_with_dots_ends_in_component(cache_clear):
+def test_get_locations_fully_qualified_with_dots_ends_in_component(cache_clear):  # noqa: ARG001
     expected = [
         ("project.components.hello_world", "HelloWorldComponent"),
     ]
@@ -66,7 +66,7 @@ def test_get_locations_fully_qualified_with_dots_ends_in_component(cache_clear):
     assert expected == actual
 
 
-def test_get_locations_fully_qualified_with_dots_does_not_end_in_view(cache_clear):
+def test_get_locations_fully_qualified_with_dots_does_not_end_in_view(cache_clear):  # noqa: ARG001
     """
     The second entry in here is a mess.
     """
@@ -83,7 +83,7 @@ def test_get_locations_fully_qualified_with_dots_does_not_end_in_view(cache_clea
     assert expected == actual
 
 
-def test_get_locations_apps_setting_tuple(settings, cache_clear):
+def test_get_locations_apps_setting_tuple(settings, cache_clear):  # noqa: ARG001
     settings.UNICORN["APPS"] = ("project",)
 
     expected = [
@@ -94,7 +94,7 @@ def test_get_locations_apps_setting_tuple(settings, cache_clear):
     assert expected == actual
 
 
-def test_get_locations_apps_setting_list(settings, cache_clear):
+def test_get_locations_apps_setting_list(settings, cache_clear):  # noqa: ARG001
     settings.UNICORN["APPS"] = [
         "project",
     ]
@@ -107,7 +107,7 @@ def test_get_locations_apps_setting_list(settings, cache_clear):
     assert expected == actual
 
 
-def test_get_locations_apps_setting_set(settings, cache_clear):
+def test_get_locations_apps_setting_set(settings, cache_clear):  # noqa: ARG001
     settings.UNICORN["APPS"] = {
         "project",
     }
@@ -120,7 +120,7 @@ def test_get_locations_apps_setting_set(settings, cache_clear):
     assert expected == actual
 
 
-def test_get_locations_apps_setting_invalid(settings, cache_clear):
+def test_get_locations_apps_setting_invalid(settings, cache_clear):  # noqa: ARG001
     settings.UNICORN["APPS"] = "project"
 
     with pytest.raises(AssertionError) as e:
@@ -130,7 +130,7 @@ def test_get_locations_apps_setting_invalid(settings, cache_clear):
     settings.UNICORN["APPS"] = ("unicorn",)
 
 
-def test_get_locations_installed_app_with_app_config(settings, clear_apps, cache_clear):
+def test_get_locations_installed_app_with_app_config(settings, clear_apps, cache_clear):  # noqa: ARG001
     settings.INSTALLED_APPS = [
         "example.coffee.apps.Config",
     ]
@@ -147,13 +147,11 @@ def test_get_locations_installed_app_with_app_config(settings, clear_apps, cache
     assert expected_location == actual_location
 
 
-def test_get_locations_installed_app_with_apps(settings, clear_apps, cache_clear):
+def test_get_locations_installed_app_with_apps(settings, clear_apps, cache_clear):  # noqa: ARG001
     # test when the app is in a subdirectory "apps"
     settings.INSTALLED_APPS = [
         "example.apps.main",
     ]
-    expected_location = [
-        ("example.apps.main.components.sidebar_menu", "SidebarMenuView")
-    ]
+    expected_location = [("example.apps.main.components.sidebar_menu", "SidebarMenuView")]
     actual_location = get_locations("sidebar-menu")
     assert expected_location == actual_location

--- a/tests/components/test_unicorn_template_response.py
+++ b/tests/components/test_unicorn_template_response.py
@@ -5,7 +5,10 @@ from django_unicorn.components.unicorn_template_response import (
     UnicornTemplateResponse,
     get_root_element,
 )
-from django_unicorn.errors import MissingComponentElement, MissingComponentViewElement
+from django_unicorn.errors import (
+    MissingComponentElementError,
+    MissingComponentViewElementError,
+)
 
 
 def test_get_root_element():
@@ -44,7 +47,7 @@ def test_get_root_element_no_element():
     component_html = "\n"
     soup = BeautifulSoup(component_html, features="html.parser")
 
-    with pytest.raises(MissingComponentElement):
+    with pytest.raises(MissingComponentElementError):
         actual = get_root_element(soup)
 
         assert str(actual) == expected
@@ -54,9 +57,7 @@ def test_get_root_element_direct_view_unicorn():
     # Annoyingly beautifulsoup adds a blank string on the attribute
     expected = '<div unicorn:view="">test</div>'
 
-    component_html = (
-        "<html><head></head>≤body><div unicorn:view>test</div></body></html>"
-    )
+    component_html = "<html><head></head>≤body><div unicorn:view>test</div></body></html>"
     soup = BeautifulSoup(component_html, features="html.parser")
     actual = get_root_element(soup)
 
@@ -78,13 +79,13 @@ def test_get_root_element_direct_view_no_view():
     component_html = "<html><head></head>≤body><div>test</div></body></html>"
     soup = BeautifulSoup(component_html, features="html.parser")
 
-    with pytest.raises(MissingComponentViewElement):
+    with pytest.raises(MissingComponentViewElementError):
         get_root_element(soup)
 
 
 def test_desoupify():
-    html = "<div>&lt;a&gt;&lt;style&gt;@keyframes x{}&lt;/style&gt;&lt;a style=&quot;animation-name:x&quot; onanimationend=&quot;alert(1)&quot;&gt;&lt;/a&gt;!\n</div>\n\n<script type=\"application/javascript\">\n  window.addEventListener('DOMContentLoaded', (event) => {\n    Unicorn.addEventListener('updated', (component) => console.log('got updated', component));\n  });\n</script>"
-    expected = "<div>&lt;a&gt;&lt;style&gt;@keyframes x{}&lt;/style&gt;&lt;a style=\"animation-name:x\" onanimationend=\"alert(1)\"&gt;&lt;/a&gt;!\n</div>\n<script type=\"application/javascript\">\n  window.addEventListener('DOMContentLoaded', (event) => {\n    Unicorn.addEventListener('updated', (component) => console.log('got updated', component));\n  });\n</script>"
+    html = "<div>&lt;a&gt;&lt;style&gt;@keyframes x{}&lt;/style&gt;&lt;a style=&quot;animation-name:x&quot; onanimationend=&quot;alert(1)&quot;&gt;&lt;/a&gt;!\n</div>\n\n<script type=\"application/javascript\">\n  window.addEventListener('DOMContentLoaded', (event) => {\n    Unicorn.addEventListener('updated', (component) => console.log('got updated', component));\n  });\n</script>"  # noqa: E501
+    expected = "<div>&lt;a&gt;&lt;style&gt;@keyframes x{}&lt;/style&gt;&lt;a style=\"animation-name:x\" onanimationend=\"alert(1)\"&gt;&lt;/a&gt;!\n</div>\n<script type=\"application/javascript\">\n  window.addEventListener('DOMContentLoaded', (event) => {\n    Unicorn.addEventListener('updated', (component) => console.log('got updated', component));\n  });\n</script>"  # noqa: E501
 
     soup = BeautifulSoup(html, "html.parser")
 

--- a/tests/management/commands/startunicorn/test_handle.py
+++ b/tests/management/commands/startunicorn/test_handle.py
@@ -2,9 +2,8 @@ import io
 import os
 import uuid
 
-from django.core.management.base import CommandError
-
 import pytest
+from django.core.management.base import CommandError
 
 from django_unicorn.management.commands.startunicorn import Command
 
@@ -30,7 +29,7 @@ def test_handle_new_app(settings, tmp_path, monkeypatch, capsys):
     # Prevent the `startapp` command from actually creating a new app
     monkeypatch.setattr(
         "django_unicorn.management.commands.startunicorn.call_command",
-        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,  # noqa: ARG005
     )
 
     app_name = f"test-{uuid.uuid4()}".replace("-", "_")
@@ -54,7 +53,7 @@ def test_handle_existing_app(settings, tmp_path, monkeypatch, capsys):
 
     monkeypatch.setattr(
         "django_unicorn.management.commands.startunicorn.get_app_path",
-        lambda a: tmp_path / app_name,
+        lambda _: tmp_path / app_name,
     )
 
     # Reply "n" to starring question
@@ -81,7 +80,7 @@ def test_handle_existing_component(settings, tmp_path, monkeypatch, capsys):
 
     monkeypatch.setattr(
         "django_unicorn.management.commands.startunicorn.get_app_path",
-        lambda a: tmp_path / app_name,
+        lambda _: tmp_path / app_name,
     )
 
     (tmp_path / app_name).mkdir()
@@ -107,7 +106,7 @@ def test_handle_existing_templates(settings, tmp_path, monkeypatch, capsys):
 
     monkeypatch.setattr(
         "django_unicorn.management.commands.startunicorn.get_app_path",
-        lambda a: tmp_path / app_name,
+        lambda _: tmp_path / app_name,
     )
 
     (tmp_path / app_name).mkdir()
@@ -134,7 +133,7 @@ def test_handle_existing_unicorn_templates(settings, tmp_path, monkeypatch, caps
 
     monkeypatch.setattr(
         "django_unicorn.management.commands.startunicorn.get_app_path",
-        lambda a: tmp_path / app_name,
+        lambda _: tmp_path / app_name,
     )
 
     (tmp_path / app_name).mkdir()
@@ -209,7 +208,7 @@ def test_handle_reply_yes_star(settings, tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("sys.stdin", io.StringIO("y\ny\n"))
 
     # Patch opening a webbrowser
-    def webbrowser_open(url, **kwargs):
+    def webbrowser_open(url, **kwargs):  # noqa: ARG001
         assert url == "https://github.com/adamghill/django-unicorn"
 
     monkeypatch.setattr("webbrowser.open", webbrowser_open)
@@ -217,7 +216,7 @@ def test_handle_reply_yes_star(settings, tmp_path, monkeypatch, capsys):
     # Prevent the `startapp` command from actually creating a new app
     monkeypatch.setattr(
         "django_unicorn.management.commands.startunicorn.call_command",
-        lambda *args, **kwargs: None,
+        lambda *args, **kwargs: None,  # noqa: ARG005
     )
 
     app_name = f"test-{uuid.uuid4()}".replace("-", "_")

--- a/tests/serializer/test_dumps.py
+++ b/tests/serializer/test_dumps.py
@@ -2,13 +2,12 @@ import json
 import uuid
 from datetime import timedelta
 from decimal import Decimal
-from typing import Dict
 from types import MappingProxyType
-
-from django.db import models
-from django.utils.timezone import now
+from typing import Dict
 
 import pytest
+from django.db import models
+from django.utils.timezone import now
 
 from django_unicorn import serializer
 from django_unicorn.serializer import InvalidFieldAttributeError, InvalidFieldNameError
@@ -141,9 +140,7 @@ def test_simple_model():
 def test_subclass_simple_model():
     expected = {"subclass_name": "def", "pk": 2, "name": "abc"}
 
-    subclass_simple_test_model = SubclassSimpleTestModel(
-        id=2, name="abc", subclass_name="def"
-    )
+    subclass_simple_test_model = SubclassSimpleTestModel(id=2, name="abc", subclass_name="def")
     actual = serializer.dumps(subclass_simple_test_model)
 
     assert_dicts(expected, actual)
@@ -211,7 +208,7 @@ def test_subclass_complicated_model():
     assert_dicts(expected, actual)
 
 
-def test_model_with_timedelta(db):
+def test_model_with_timedelta(db):  # noqa: ARG001
     now_dt = now()
     duration = timedelta(days=-1, seconds=68400)
 
@@ -247,7 +244,7 @@ def test_model_with_timedelta(db):
     assert_dicts(expected, actual)
 
 
-def test_model_with_datetime_as_string(db):
+def test_model_with_datetime_as_string(db):  # noqa: ARG001
     datetime = now().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
     flavor = Flavor(name="name1", datetime=datetime)
 
@@ -274,7 +271,7 @@ def test_model_with_datetime_as_string(db):
     assert_dicts(expected, actual)
 
 
-def test_model_with_time_as_string(db):
+def test_model_with_time_as_string(db):  # noqa: ARG001
     time = now().strftime("%H:%M:%S.%f")[:-3]
     flavor = Flavor(name="name1", time=time)
 
@@ -301,7 +298,7 @@ def test_model_with_time_as_string(db):
     assert_dicts(expected, actual)
 
 
-def test_model_with_duration_as_string(db):
+def test_model_with_duration_as_string(db):  # noqa: ARG001
     duration = "-1 day, 19:00:00"
     flavor = Flavor(name="name1", duration=duration)
 
@@ -340,9 +337,7 @@ def test_model_foreign_key():
 
 def test_model_foreign_key_subclass():
     test_model_one = ForeignKeyTestModel(id=1, name="abc")
-    test_model_two = SubclassForeignKeyTestModel(
-        id=2, name="def", subclass_name="ghi", parent=test_model_one
-    )
+    test_model_two = SubclassForeignKeyTestModel(id=2, name="def", subclass_name="ghi", parent=test_model_one)
     expected = {"name": "def", "parent": 1, "pk": 2, "subclass_name": "ghi"}
 
     actual = serializer.dumps(test_model_two)
@@ -355,9 +350,7 @@ def test_model_inherited_model_with_many_to_many_and_foreign_key():
     flavor_one = Flavor(id=3, name="name0")
     flavor_one.save()
 
-    flavor_two = NewFlavor(
-        id=4, new_name="new_name_1", name="name_1", parent=flavor_one
-    )
+    flavor_two = NewFlavor(id=4, new_name="new_name_1", name="name_1", parent=flavor_one)
     flavor_two.save()
 
     taste1 = Taste(name="Bitter1")
@@ -451,9 +444,7 @@ def test_model_many_to_many_with_excludes(django_assert_num_queries):
     flavor_one.taste_set.add(taste2)
     flavor_one.taste_set.add(taste3)
 
-    flavor_one = Flavor.objects.prefetch_related("taste_set", "origins").get(
-        pk=flavor_one.pk
-    )
+    flavor_one = Flavor.objects.prefetch_related("taste_set", "origins").get(pk=flavor_one.pk)
 
     # This shouldn't make any database calls because of the prefetch_related
     with django_assert_num_queries(0):
@@ -486,7 +477,7 @@ def test_model_many_to_many_with_excludes(django_assert_num_queries):
 
 
 @pytest.mark.django_db
-def test_dumps_queryset(db):
+def test_dumps_queryset(db):  # noqa: ARG001
     flavor_one = Flavor(name="name1", label="label1")
     flavor_one.save()
 
@@ -631,9 +622,7 @@ def test_get_model_dict_many_to_many_is_referenced_prefetched(
         "origins": [],
     }
 
-    flavor_one = (
-        Flavor.objects.prefetch_related("taste_set").filter(id=flavor_one.id).first()
-    )
+    flavor_one = Flavor.objects.prefetch_related("taste_set").filter(id=flavor_one.id).first()
 
     # prefetch_related should reduce the database calls
     with django_assert_num_queries(1):
@@ -748,11 +737,7 @@ def test_exclude_field_attributes_nested():
     expected = '{"classic":{"book":{"title":"The Grapes of Wrath"}}}'
 
     actual = serializer.dumps(
-        {
-            "classic": {
-                "book": {"title": "The Grapes of Wrath", "author": "John Steinbeck"}
-            }
-        },
+        {"classic": {"book": {"title": "The Grapes of Wrath", "author": "John Steinbeck"}}},
         exclude_field_attributes=("classic.book.author",),
     )
 
@@ -799,10 +784,7 @@ def test_exclude_field_attributes_invalid_name():
             exclude_field_attributes=("blob.monster",),
         )
 
-    assert (
-        e.exconly()
-        == "django_unicorn.serializer.InvalidFieldNameError: Cannot resolve 'blob'. Choices are: book"
-    )
+    assert e.exconly() == "django_unicorn.serializer.InvalidFieldNameError: Cannot resolve 'blob'. Choices are: book"
 
 
 def test_exclude_field_attributes_invalid_attribute():
@@ -814,12 +796,12 @@ def test_exclude_field_attributes_invalid_attribute():
 
     assert (
         e.exconly()
-        == "django_unicorn.serializer.InvalidFieldAttributeError: Cannot resolve 'blob'. Choices on 'book' are: title, author"
+        == "django_unicorn.serializer.InvalidFieldAttributeError: Cannot resolve 'blob'. Choices on 'book' are: title, author"  # noqa: E501
     )
 
 
 def test_exclude_field_attributes_invalid_type():
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(AssertionError):
         serializer.dumps(
             {"book": {"title": "The Grapes of Wrath", "author": "John Steinbeck"}},
             exclude_field_attributes=("book.blob"),

--- a/tests/serializer/test_model_value.py
+++ b/tests/serializer/test_model_value.py
@@ -1,6 +1,5 @@
-from django.db import models
-
 import pytest
+from django.db import models
 
 from django_unicorn.components import ModelValueMixin
 from django_unicorn.serializer import model_value

--- a/tests/templatetags/test_unicorn_render.py
+++ b/tests/templatetags/test_unicorn_render.py
@@ -1,12 +1,11 @@
 import re
 
+import pytest
 from django.template import Context
 from django.template.base import Parser, Token, TokenType
 
-import pytest
-
 from django_unicorn.components import UnicornView
-from django_unicorn.errors import ComponentNotValid
+from django_unicorn.errors import ComponentNotValidError
 from django_unicorn.templatetags.unicorn import unicorn
 from django_unicorn.utils import generate_checksum
 from example.coffee.models import Flavor
@@ -98,10 +97,7 @@ def test_unicorn_template_renders(client):
     assert response.wsgi_request.path == "/test"
     assert "WSGIRequest" in content
     assert content.startswith("<div unicorn:id")
-    assert (
-        'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentKwargs"'
-        in content
-    )
+    assert 'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentKwargs"' in content
     assert '<script type="application/json" id="unicorn:data:' in content
 
 
@@ -111,14 +107,8 @@ def test_unicorn_template_renders_with_parent_and_child(client):
 
     assert response.wsgi_request.path == "/test-parent"
     assert content.startswith("<div unicorn:id")
-    assert (
-        'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentParent"'
-        in content
-    )
-    assert (
-        'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentChild"'
-        in content
-    )
+    assert 'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentParent"' in content
+    assert 'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentChild"' in content
     assert "--parent--" in content
     assert "==child==" in content
     assert '<script type="application/json" id="unicorn:data:' in content
@@ -130,14 +120,8 @@ def test_unicorn_template_renders_with_parent_and_child_with_templateview(client
 
     assert response.wsgi_request.path == "/test-parent-template"
     assert content.startswith("<div unicorn:id")
-    assert (
-        'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentParent"'
-        in content
-    )
-    assert (
-        'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentChild"'
-        in content
-    )
+    assert 'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentParent"' in content
+    assert 'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentChild"' in content
     assert "--parent--" in content
     assert "==child==" in content
     assert '<script type="application/json" id="unicorn:data:' in content
@@ -149,14 +133,8 @@ def test_unicorn_template_renders_with_implicit_parent_and_child(client):
 
     assert response.wsgi_request.path == "/test-parent-implicit"
     assert content.startswith("<div unicorn:id")
-    assert (
-        'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentParentImplicit"'
-        in content
-    )
-    assert (
-        'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentChildImplicit"'
-        in content
-    )
+    assert 'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentParentImplicit"' in content
+    assert 'unicorn:name="tests.templatetags.test_unicorn_render.FakeComponentChildImplicit"' in content
     assert "--parent--" in content
     assert "==child==" in content
     assert "has_parent:True" in content
@@ -223,10 +201,7 @@ def test_unicorn_render_parent(settings):
     unicorn_node.render(Context(context))
 
     assert unicorn_node.parent
-    assert (
-        unicorn_node.component_id
-        == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs"
-    )
+    assert unicorn_node.component_id == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs"
 
 
 def test_unicorn_render_parent_with_key(settings):
@@ -240,10 +215,7 @@ def test_unicorn_render_parent_with_key(settings):
     context = {"view": view}
     unicorn_node.render(Context(context))
 
-    assert (
-        unicorn_node.component_id
-        == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs:blob"
-    )
+    assert unicorn_node.component_id == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs:blob"
 
 
 def test_unicorn_render_parent_with_id(settings):
@@ -257,10 +229,7 @@ def test_unicorn_render_parent_with_id(settings):
     context = {"view": view}
     unicorn_node.render(Context(context))
 
-    assert (
-        unicorn_node.component_id
-        == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs:flob"
-    )
+    assert unicorn_node.component_id == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs:flob"
 
 
 def test_unicorn_render_parent_with_pk(settings):
@@ -274,10 +243,7 @@ def test_unicorn_render_parent_with_pk(settings):
     context = {"view": view}
     unicorn_node.render(Context(context))
 
-    assert (
-        unicorn_node.component_id
-        == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs:99"
-    )
+    assert unicorn_node.component_id == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs:99"
 
 
 def test_unicorn_render_parent_with_model_id(settings):
@@ -292,10 +258,7 @@ def test_unicorn_render_parent_with_model_id(settings):
     context = {"view": view, "model": FakeModel()}
     unicorn_node.render(Context(context))
 
-    assert (
-        unicorn_node.component_id
-        == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs:178"
-    )
+    assert unicorn_node.component_id == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs:178"
 
 
 @pytest.mark.django_db
@@ -313,10 +276,7 @@ def test_unicorn_render_parent_with_model_pk(settings):
     context = {"view": view, "model": flavor}
     unicorn_node.render(Context(context))
 
-    assert (
-        unicorn_node.component_id
-        == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs:187"
-    )
+    assert unicorn_node.component_id == "asdf:tests.templatetags.test_unicorn_render.FakeComponentKwargs:187"
 
 
 def test_unicorn_render_id_use_pk():
@@ -502,10 +462,10 @@ def test_unicorn_render_with_invalid_component_name_from_context():
     unicorn_node = unicorn(Parser([]), token)
     context = {"component_name": "tests.templatetags.test_unicorn_render.FakeComponent"}
 
-    with pytest.raises(ComponentNotValid) as e:
+    with pytest.raises(ComponentNotValidError) as e:
         unicorn_node.render(Context(context))
 
     assert (
         e.exconly()
-        == "django_unicorn.errors.ComponentNotValid: Component template is not valid: bad_component_name."
+        == "django_unicorn.errors.ComponentNotValidError: Component template is not valid: bad_component_name."
     )

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -1,8 +1,6 @@
-import uuid
-
 import pytest
 
-from django_unicorn.components import UnicornView, unicorn_view
+from django_unicorn.components import UnicornView
 from django_unicorn.serializer import dumps, loads
 from django_unicorn.views.utils import _construct_model, set_property_from_data
 from example.coffee.models import Flavor

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -32,9 +32,7 @@ def test_get_serial_enabled(settings):
 
     settings.UNICORN["SERIAL"]["ENABLED"] = True
     settings.CACHES["unicorn_cache"] = {}
-    settings.CACHES["unicorn_cache"][
-        "BACKEND"
-    ] = "django.core.cache.backends.dummy.DummyCache"
+    settings.CACHES["unicorn_cache"]["BACKEND"] = "django.core.cache.backends.dummy.DummyCache"
     settings.UNICORN["CACHE_ALIAS"] = "unicorn_cache"
     assert get_serial_enabled() is False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,8 +72,8 @@ def test_get_type_hints_missing_type_hints():
 
 
 def test_sanitize_html():
-    expected = '{"id":"abcd123","name":"text-inputs","key":"asdf","data":{"name":"World","testing_thing":"Whatever \\u003C/script\\u003E \\u003Cscript\\u003Ealert(\'uh oh\')\\u003C/script\\u003E"},"calls":[],"hash":"hjkl"}'
-    data = '{"id":"abcd123","name":"text-inputs","key":"asdf","data":{"name":"World","testing_thing":"Whatever </script> <script>alert(\'uh oh\')</script>"},"calls":[],"hash":"hjkl"}'
+    expected = '{"id":"abcd123","name":"text-inputs","key":"asdf","data":{"name":"World","testing_thing":"Whatever \\u003C/script\\u003E \\u003Cscript\\u003Ealert(\'uh oh\')\\u003C/script\\u003E"},"calls":[],"hash":"hjkl"}'  # noqa: E501
+    data = '{"id":"abcd123","name":"text-inputs","key":"asdf","data":{"name":"World","testing_thing":"Whatever </script> <script>alert(\'uh oh\')</script>"},"calls":[],"hash":"hjkl"}'  # noqa: E501
     actual = sanitize_html(data)
     assert actual == expected
 
@@ -106,12 +106,8 @@ def test_cacheable_component_extra_context_is_none_then_restored():
 
 def test_cacheable_component_parents_have_request_restored():
     component = FakeComponent(component_id="asdf123498", component_name="hello-world")
-    component2 = FakeComponent(
-        component_id="asdf123499", component_name="hello-world", parent=component
-    )
-    component3 = FakeComponent(
-        component_id="asdf123500", component_name="hello-world", parent=component2
-    )
+    component2 = FakeComponent(component_id="asdf123499", component_name="hello-world", parent=component)
+    component3 = FakeComponent(component_id="asdf123500", component_name="hello-world", parent=component2)
     request = MagicMock()
     extra_content = "extra_content"
     for c in [component, component2, component3]:
@@ -214,24 +210,12 @@ def test_caching_components(settings):
     }
     settings.UNICORN["CACHE_ALIAS"] = "default"
     root = ExampleCachingComponent(component_id="rrr", component_name="root")
-    child1 = ExampleCachingComponent(
-        component_id="1111", component_name="child1", parent=root
-    )
-    child2 = ExampleCachingComponent(
-        component_id="2222", component_name="child2", parent=root
-    )
-    child3 = ExampleCachingComponent(
-        component_id="3333", component_name="child3", parent=root
-    )
-    grandchild = ExampleCachingComponent(
-        component_id="4444", component_name="grandchild", parent=child1
-    )
-    grandchild2 = ExampleCachingComponent(
-        component_id="5555", component_name="grandchild2", parent=child1
-    )
-    grandchild3 = ExampleCachingComponent(
-        component_id="6666", component_name="grandchild3", parent=child3
-    )
+    child1 = ExampleCachingComponent(component_id="1111", component_name="child1", parent=root)
+    child2 = ExampleCachingComponent(component_id="2222", component_name="child2", parent=root)
+    child3 = ExampleCachingComponent(component_id="3333", component_name="child3", parent=root)
+    grandchild = ExampleCachingComponent(component_id="4444", component_name="grandchild", parent=child1)
+    grandchild2 = ExampleCachingComponent(component_id="5555", component_name="grandchild2", parent=child1)
+    grandchild3 = ExampleCachingComponent(component_id="6666", component_name="grandchild3", parent=child3)
 
     cache_full_tree(child3)
     request = MagicMock()
@@ -251,6 +235,4 @@ def test_caching_components(settings):
         assert restored_root.children[0].children[i].component_id == child.component_id
     assert not restored_root.children[1].children
     assert 1 == len(restored_root.children[2].children)
-    assert (
-        grandchild3.component_id == restored_root.children[2].children[0].component_id
-    )
+    assert grandchild3.component_id == restored_root.children[2].children[0].component_id

--- a/tests/views/action_parsers/utils/test_set_property_value.py
+++ b/tests/views/action_parsers/utils/test_set_property_value.py
@@ -11,8 +11,8 @@ from example.coffee.models import Flavor, Taste
 class FakeComponent(UnicornView):
     string = "property_view"
     integer = 99
-    datetime = datetime(2020, 1, 1)
-    array: List[str] = []
+    datetime = datetime(2020, 1, 1)  # noqa: DTZ001
+    array: List[str] = []  # noqa: RUF012
     model = Flavor(name="initial-flavor")
     queryset = Flavor.objects.none()
     taste = Taste(name="bitter")
@@ -51,9 +51,9 @@ def test_set_property_value_int():
 
 def test_set_property_value_datetime():
     component = FakeComponent(component_name="test", component_id="12345678")
-    assert datetime(2020, 1, 1) == component.datetime
+    assert datetime(2020, 1, 1) == component.datetime  # noqa: DTZ001
 
-    dt = datetime(2020, 1, 2)
+    dt = datetime(2020, 1, 2)  # noqa: DTZ001
     data = {"datetime": None}
 
     set_property_value(component, "datetime", dt, data)

--- a/tests/views/fake_components.py
+++ b/tests/views/fake_components.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict
 
 from django import forms
@@ -18,10 +18,10 @@ from example.coffee.models import Flavor
 
 class FakeComponent(UnicornView):
     template_name = "templates/test_component.html"
-    dictionary = {"name": "test"}
+    dictionary = {"name": "test"}  # noqa: RUF012
     method_count = 0
     check = False
-    nested = {"check": False, "another": {"bool": False}}
+    nested = {"check": False, "another": {"bool": False}}  # noqa: RUF012
     method_arg = ""
 
     def test_method(self):
@@ -62,9 +62,7 @@ class FakeComponent(UnicornView):
         raise ValidationError("Check is required", code="required")
 
     def test_validation_error_list(self):
-        raise ValidationError(
-            [ValidationError({"check": "Check is required"}, code="required")]
-        )
+        raise ValidationError([ValidationError({"check": "Check is required"}, code="required")])
 
 
 class FakeModelComponent(UnicornView):
@@ -88,7 +86,7 @@ class FakeValidationComponent(UnicornView):
 
     text = "hello"
     number = ""
-    date_time = datetime(2020, 9, 13, 17, 45, 14)
+    date_time = datetime(2020, 9, 13, 17, 45, 14, tzinfo=timezone.utc)
     permanent = True
 
     def set_text_no_validation(self):
@@ -135,7 +133,7 @@ class FakeComponentWithError(UnicornView):
     template_name = "templates/test_component.html"
 
     def mount(self):
-        print(self.not_a_valid_attribute)
+        print(self.not_a_valid_attribute)  # noqa: T201
 
 
 global count_updating
@@ -150,15 +148,15 @@ class FakeComponentWithUpdateMethods(UnicornView):
 
     count = 0
 
-    def updating_count(self, c):
-        global count_updating
+    def updating_count(self, _):
+        global count_updating  # noqa: PLW0603
         count_updating += 1
 
         if count_updating >= 2:
             raise Exception("updating_count called more than once")
 
-    def updated_count(self, c):
-        global count_updated
+    def updated_count(self, _):
+        global count_updated  # noqa: PLW0603
         count_updated += 1
 
         if count_updated >= 2:

--- a/tests/views/message/test_call_method.py
+++ b/tests/views/message/test_call_method.py
@@ -1,16 +1,19 @@
 import time
-from typing import Dict
+from typing import Dict, Optional
 
 import orjson
 import shortuuid
+from tests.views.message.utils import post_and_get_response
 
 from django_unicorn.components import UnicornView, unicorn_view
 from django_unicorn.utils import generate_checksum
-from tests.views.message.utils import post_and_get_response
 
 
 def _post_to_component(
-    client, method_name: str, component_name: str = "FakeComponent", data: Dict = None
+    client,
+    method_name: str,
+    component_name: str = "FakeComponent",
+    data: Optional[Dict] = None,
 ) -> str:
     if data is None:
         data = {}
@@ -54,9 +57,7 @@ def test_message_call_method_redirect(client):
 
 
 def test_message_call_method_with_message(client):
-    body = _post_to_component(
-        client, method_name="test_message", component_name="FakeComponentWithMessage"
-    )
+    body = _post_to_component(client, method_name="test_message", component_name="FakeComponentWithMessage")
 
     assert not body["errors"]
 
@@ -158,9 +159,7 @@ def test_message_call_method_nested_setter(client):
 
 def test_message_call_method_multiple_nested_setter(client):
     data = {"nested": {"another": {"bool": True}}}
-    body = _post_to_component(
-        client, method_name="nested.another.bool=False", data=data
-    )
+    body = _post_to_component(client, method_name="nested.another.bool=False", data=data)
 
     assert body["data"].get("nested").get("another").get("bool") is False
 
@@ -188,9 +187,7 @@ def test_message_call_method_args(client):
 
 def test_message_call_method_kwargs(client):
     data = {"method_count": 0}
-    body = _post_to_component(
-        client, method_name="test_method_kwargs(count=99)", data=data
-    )
+    body = _post_to_component(client, method_name="test_method_kwargs(count=99)", data=data)
 
     assert body["data"].get("method_count") == 99
 
@@ -252,9 +249,7 @@ def test_message_call_method_refresh(client):
 
 def test_message_call_method_caches_disabled(client, monkeypatch, settings):
     monkeypatch.setattr(unicorn_view, "COMPONENTS_MODULE_CACHE_ENABLED", False)
-    settings.CACHES["default"][
-        "BACKEND"
-    ] = "django.core.cache.backends.dummy.DummyCache"
+    settings.CACHES["default"]["BACKEND"] = "django.core.cache.backends.dummy.DummyCache"
 
     component_id = shortuuid.uuid()[:8]
     response = post_and_get_response(
@@ -288,9 +283,7 @@ def test_message_call_method_caches_disabled(client, monkeypatch, settings):
 def test_message_call_method_module_cache_disabled(client, monkeypatch, settings):
     monkeypatch.setattr(unicorn_view, "COMPONENTS_MODULE_CACHE_ENABLED", False)
     settings.UNICORN["CACHE_ALIAS"] = "default"
-    settings.CACHES["default"][
-        "BACKEND"
-    ] = "django.core.cache.backends.locmem.LocMemCache"
+    settings.CACHES["default"]["BACKEND"] = "django.core.cache.backends.locmem.LocMemCache"
 
     component_id = shortuuid.uuid()[:8]
     response = post_and_get_response(
@@ -323,9 +316,7 @@ def test_message_call_method_module_cache_disabled(client, monkeypatch, settings
 
 def test_message_call_method_cache_backend_dummy(client, monkeypatch, settings):
     monkeypatch.setattr(unicorn_view, "COMPONENTS_MODULE_CACHE_ENABLED", True)
-    settings.CACHES["default"][
-        "BACKEND"
-    ] = "django.core.cache.backends.dummy.DummyCache"
+    settings.CACHES["default"]["BACKEND"] = "django.core.cache.backends.dummy.DummyCache"
 
     component_id = shortuuid.uuid()[:8]
     response = post_and_get_response(

--- a/tests/views/message/test_call_method_multiple.py
+++ b/tests/views/message/test_call_method_multiple.py
@@ -108,7 +108,7 @@ def test_message_two(client, settings):
 
         second_result = results[1]
         second_body = orjson.loads(second_result.content)
-        assert second_body["queued"] == True
+        assert second_body["queued"] is True
 
 
 @pytest.mark.slow
@@ -139,9 +139,8 @@ def test_message_multiple(client, settings):
         assert first_body["data"].get("counter") == len(results)
 
         for result in results[1:]:
-            result = results[1]
             body = orjson.loads(result.content)
-            assert body.get("queued") == True
+            assert body.get("queued") is True
 
 
 @pytest.mark.slow
@@ -173,9 +172,8 @@ def test_message_multiple_return_is_correct(client, settings):
         assert first_body["return"].get("value") == len(results)
 
         for result in results[1:]:
-            result = results[1]
             body = orjson.loads(result.content)
-            assert body.get("queued") == True
+            assert body.get("queued") is True
 
 
 @pytest.mark.slow
@@ -206,9 +204,7 @@ def test_message_multiple_with_updated_data(client, settings):
     # sure how to reconcile this with resulting data from queued messages
     message_with_new_data = deepcopy(message)
     message_with_new_data["data"] = {"counter": 7}
-    message_with_new_data["checksum"] = generate_checksum(
-        str(message_with_new_data["data"])
-    )
+    message_with_new_data["checksum"] = generate_checksum(str(message_with_new_data["data"]))
     messages.append((client, 0.4, message_with_new_data))
 
     with ThreadPool(len(messages)) as pool:
@@ -220,9 +216,8 @@ def test_message_multiple_with_updated_data(client, settings):
         assert first_body["data"].get("counter") == 4
 
         for result in results[1:]:
-            result = results[1]
             body = orjson.loads(result.content)
-            assert body.get("queued") == True
+            assert body.get("queued") is True
 
 
 @pytest.mark.slow
@@ -324,9 +319,7 @@ def test_message_second_request_not_queued_because_serial_disabled(client, setti
 @pytest.mark.slow
 @pytest.mark.skip
 def test_message_second_request_not_queued_because_dummy_cache(client, settings):
-    _set_serial(
-        settings, True, 5, cache_backend="django.core.cache.backends.dummy.DummyCache"
-    )
+    _set_serial(settings, True, 5, cache_backend="django.core.cache.backends.dummy.DummyCache")
 
     data = {"counter": 0}
     component_id = shortuuid.uuid()[:8]

--- a/tests/views/message/test_calls.py
+++ b/tests/views/message/test_calls.py
@@ -1,5 +1,6 @@
-from django_unicorn.components import UnicornView
 from tests.views.message.utils import post_and_get_response
+
+from django_unicorn.components import UnicornView
 
 
 class FakeCallsComponent(UnicornView):
@@ -27,9 +28,7 @@ def test_message_calls(client):
         }
     ]
 
-    response = post_and_get_response(
-        client, url=FAKE_CALLS_COMPONENT_URL, action_queue=action_queue
-    )
+    response = post_and_get_response(client, url=FAKE_CALLS_COMPONENT_URL, action_queue=action_queue)
 
     assert response.get("calls") == [{"args": [], "fn": "testCall"}]
 
@@ -47,9 +46,7 @@ def test_message_multiple_calls(client):
             "target": None,
         },
     ]
-    response = post_and_get_response(
-        client, url=FAKE_CALLS_COMPONENT_URL, action_queue=action_queue
-    )
+    response = post_and_get_response(client, url=FAKE_CALLS_COMPONENT_URL, action_queue=action_queue)
 
     assert response.get("calls") == [
         {"args": [], "fn": "testCall"},
@@ -66,8 +63,6 @@ def test_message_calls_with_arg(client):
         }
     ]
 
-    response = post_and_get_response(
-        client, url=FAKE_CALLS_COMPONENT_URL, action_queue=action_queue
-    )
+    response = post_and_get_response(client, url=FAKE_CALLS_COMPONENT_URL, action_queue=action_queue)
 
     assert response.get("calls") == [{"args": ["hello"], "fn": "testCall3"}]

--- a/tests/views/message/test_get_property_value.py
+++ b/tests/views/message/test_get_property_value.py
@@ -1,8 +1,9 @@
-from django_unicorn.views.action_parsers.call_method import _get_property_value
 from tests.views.fake_components import FakeComponent
 
+from django_unicorn.views.action_parsers.call_method import _get_property_value
 
-def test_get_property_value(client):
+
+def test_get_property_value():
     component = FakeComponent(component_name="test", component_id="asdf")
 
     component.check = False
@@ -15,7 +16,7 @@ def test_get_property_value(client):
     assert check_value is True
 
 
-def test_get_property_value_nested(client):
+def test_get_property_value_nested():
     component = FakeComponent(component_name="test", component_id="asdf")
 
     component.nested["check"] = False

--- a/tests/views/message/test_hash.py
+++ b/tests/views/message/test_hash.py
@@ -1,10 +1,10 @@
 import shortuuid
-
-from django_unicorn.components import UnicornView
-from django_unicorn.utils import generate_checksum
 from tests.views.fake_components import FakeComponent
 from tests.views.message.test_calls import FakeCallsComponent
 from tests.views.message.utils import post_and_get_response
+
+from django_unicorn.components import UnicornView
+from django_unicorn.utils import generate_checksum
 
 
 class FakeComponentParent(UnicornView):
@@ -33,7 +33,7 @@ def test_message_hash_no_change(client):
         component_name="tests.views.fake_components.FakeComponent",
     )
     rendered_content = component.render()
-    hash = generate_checksum(rendered_content)
+    checksum = generate_checksum(rendered_content)
 
     data = {"method_count": 0}
     response = post_and_get_response(
@@ -47,7 +47,7 @@ def test_message_hash_no_change(client):
             }
         ],
         component_id=component_id,
-        hash=hash,
+        hash=checksum,
     )
 
     assert response.status_code == 304
@@ -60,7 +60,7 @@ def test_message_hash_changes(client):
         component_name="tests.views.fake_components.FakeComponent",
     )
     rendered_content = component.render()
-    hash = generate_checksum(rendered_content)
+    checksum = generate_checksum(rendered_content)
 
     data = {"method_count": 0}
     response = post_and_get_response(
@@ -74,7 +74,7 @@ def test_message_hash_changes(client):
             }
         ],
         component_id=component_id,
-        hash=hash,
+        hash=checksum,
     )
 
     assert response["data"]["method_count"] == 1
@@ -87,7 +87,7 @@ def test_message_hash_no_change_but_return_value(client):
         component_name="tests.views.fake_components.FakeComponent",
     )
     rendered_content = component.render()
-    hash = generate_checksum(rendered_content)
+    checksum = generate_checksum(rendered_content)
 
     data = {"method_count": 0}
     response = post_and_get_response(
@@ -101,7 +101,7 @@ def test_message_hash_no_change_but_return_value(client):
             }
         ],
         component_id=component_id,
-        hash=hash,
+        hash=checksum,
     )
 
     # check that the response is JSON and not a 304
@@ -116,7 +116,7 @@ def test_message_hash_no_change_but_return_redirect(client):
         component_name="tests.views.fake_components.FakeComponent",
     )
     rendered_content = component.render()
-    hash = generate_checksum(rendered_content)
+    checksum = generate_checksum(rendered_content)
 
     data = {"method_count": 0}
     response = post_and_get_response(
@@ -130,7 +130,7 @@ def test_message_hash_no_change_but_return_redirect(client):
             }
         ],
         component_id=component_id,
-        hash=hash,
+        hash=checksum,
     )
 
     # check that the response is JSON and not a 304
@@ -145,7 +145,7 @@ def test_message_hash_no_change_but_return_hash_update(client):
         component_name="tests.views.fake_components.FakeComponent",
     )
     rendered_content = component.render()
-    hash = generate_checksum(rendered_content)
+    checksum = generate_checksum(rendered_content)
 
     data = {"method_count": 0}
     response = post_and_get_response(
@@ -159,7 +159,7 @@ def test_message_hash_no_change_but_return_hash_update(client):
             }
         ],
         component_id=component_id,
-        hash=hash,
+        hash=checksum,
     )
 
     # check that the response is JSON and not a 304
@@ -174,7 +174,7 @@ def test_message_hash_no_change_but_return_poll_update(client):
         component_name="tests.views.fake_components.FakeComponent",
     )
     rendered_content = component.render()
-    hash = generate_checksum(rendered_content)
+    checksum = generate_checksum(rendered_content)
 
     data = {"method_count": 0}
     response = post_and_get_response(
@@ -188,7 +188,7 @@ def test_message_hash_no_change_but_return_poll_update(client):
             }
         ],
         component_id=component_id,
-        hash=hash,
+        hash=checksum,
     )
 
     # check that the response is JSON and not a 304
@@ -203,7 +203,7 @@ def test_message_hash_no_change_but_return_location_update(client):
         component_name="tests.views.fake_components.FakeComponent",
     )
     rendered_content = component.render()
-    hash = generate_checksum(rendered_content)
+    checksum = generate_checksum(rendered_content)
 
     data = {"method_count": 0}
     response = post_and_get_response(
@@ -217,7 +217,7 @@ def test_message_hash_no_change_but_return_location_update(client):
             }
         ],
         component_id=component_id,
-        hash=hash,
+        hash=checksum,
     )
 
     # check that the response is JSON and not a 304
@@ -232,7 +232,7 @@ def test_message_hash_no_change_but_calls(client):
         component_name="tests.views.message.test_calls.FakeCallsComponent",
     )
     rendered_content = component.render()
-    hash = generate_checksum(rendered_content)
+    checksum = generate_checksum(rendered_content)
 
     data = {}
     response = post_and_get_response(
@@ -246,7 +246,7 @@ def test_message_hash_no_change_but_calls(client):
             }
         ],
         component_id=component_id,
-        hash=hash,
+        hash=checksum,
     )
 
     # check that the response is JSON and not a 304

--- a/tests/views/message/test_message.py
+++ b/tests/views/message/test_message.py
@@ -1,8 +1,7 @@
 import time
 
-from django.http import JsonResponse
-
 import pytest
+from django.http import JsonResponse
 
 from django_unicorn.errors import ComponentClassLoadError, ComponentModuleLoadError
 from django_unicorn.views import message
@@ -117,10 +116,9 @@ def test_message_component_class_not_loaded(client):
             url="/message/tests.views.fake_components.FakeComponentNotThere",
         )
 
-    print(e.value.locations)
     assert (
         e.exconly()
-        == "django_unicorn.errors.ComponentClassLoadError: The component class 'tests.views.fake_components.FakeComponentNotThere' could not be loaded."
+        == "django_unicorn.errors.ComponentClassLoadError: The component class 'tests.views.fake_components.FakeComponentNotThere' could not be loaded."  # noqa: E501
     )
     assert e.value.locations == [
         ("tests.views.fake_components", "FakeComponentNotThere"),

--- a/tests/views/message/test_set_property.py
+++ b/tests/views/message/test_set_property.py
@@ -6,9 +6,7 @@ import shortuuid
 from django_unicorn.utils import generate_checksum
 
 
-def _post_message_and_get_body(
-    client, message, url="/message/tests.views.fake_components.FakeComponent"
-):
+def _post_message_and_get_body(client, message, url="/message/tests.views.fake_components.FakeComponent"):
     response = client.post(
         url,
         message,

--- a/tests/views/message/test_target.py
+++ b/tests/views/message/test_target.py
@@ -1,6 +1,5 @@
 import time
 
-import orjson
 import shortuuid
 from bs4 import BeautifulSoup
 
@@ -44,7 +43,7 @@ def test_message_generated_checksum_matches_dom_checksum(client):
 
     assert dom
     assert not body.get("partials")
-    assert body.get("data", {}).get("clicked") == True
+    assert body.get("data", {}).get("clicked") is True
 
     soup = BeautifulSoup(dom, features="html.parser")
 
@@ -80,7 +79,7 @@ def test_message_target_invalid(client):
 
     assert body.get("dom")
     assert not body.get("partials")
-    assert body.get("data", {}).get("clicked") == True
+    assert body.get("data", {}).get("clicked") is True
 
 
 def test_message_target_id(client):
@@ -111,7 +110,7 @@ def test_message_target_id(client):
     assert len(body["partials"]) == 1
     assert body["partials"][0]["id"] == "test-target-id"
     assert body["partials"][0]["dom"] == '<div id="test-target-id"></div>'
-    assert body.get("data", {}).get("clicked") == True
+    assert body.get("data", {}).get("clicked") is True
 
 
 def test_message_target_only_id(client):
@@ -142,7 +141,7 @@ def test_message_target_only_id(client):
     assert len(body["partials"]) == 1
     assert body["partials"][0]["id"] == "test-target-id"
     assert body["partials"][0]["dom"] == '<div id="test-target-id"></div>'
-    assert body.get("data", {}).get("clicked") == True
+    assert body.get("data", {}).get("clicked") is True
 
 
 def test_message_target_only_key(client):
@@ -173,7 +172,7 @@ def test_message_target_only_key(client):
     assert len(body["partials"]) == 1
     assert body["partials"][0]["key"] == "test-target-key"
     assert body["partials"][0]["dom"] == '<div unicorn:key="test-target-key"></div>'
-    assert body.get("data", {}).get("clicked") == True
+    assert body.get("data", {}).get("clicked") is True
 
 
 def test_message_target_key(client):
@@ -204,4 +203,4 @@ def test_message_target_key(client):
     assert len(body["partials"]) == 1
     assert body["partials"][0]["key"] == "test-target-key"
     assert body["partials"][0]["dom"] == '<div unicorn:key="test-target-key"></div>'
-    assert body.get("data", {}).get("clicked") == True
+    assert body.get("data", {}).get("clicked") is True

--- a/tests/views/message/test_toggle.py
+++ b/tests/views/message/test_toggle.py
@@ -32,7 +32,7 @@ def test_message_toggle(client):
     body = _post_message_and_get_body(client, message)
 
     assert not body["errors"]
-    assert body["data"]["check"] == True
+    assert body["data"]["check"] is True
 
 
 def test_message_nested_toggle(client):
@@ -50,4 +50,4 @@ def test_message_nested_toggle(client):
     body = _post_message_and_get_body(client, message)
 
     assert not body["errors"]
-    assert body["data"]["nested"]["check"] == True
+    assert body["data"]["nested"]["check"] is True

--- a/tests/views/message/test_type_hints.py
+++ b/tests/views/message/test_type_hints.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass
 from decimal import Decimal
 
-import orjson
+from tests.views.message.utils import post_and_get_response
 
 from django_unicorn.components import UnicornView
-from tests.views.message.utils import post_and_get_response
 
 
 @dataclass
@@ -34,9 +33,7 @@ class FakeObjectsComponent(UnicornView):
         assert self.dataclass_example.hello == "world"
 
 
-FAKE_OBJECTS_COMPONENT_URL = (
-    "/message/tests.views.message.test_type_hints.FakeObjectsComponent"
-)
+FAKE_OBJECTS_COMPONENT_URL = "/message/tests.views.message.test_type_hints.FakeObjectsComponent"
 
 
 def test_message_int(client):
@@ -54,9 +51,7 @@ def test_message_int(client):
         action_queue=action_queue,
     )
 
-    assert not response.get(
-        "error"
-    )  # UnicornViewError/AssertionError returns a a JsonResponse with "error" key
+    assert not response.get("error")  # UnicornViewError/AssertionError returns a a JsonResponse with "error" key
     assert not response["errors"]
 
 
@@ -75,9 +70,7 @@ def test_message_float(client):
         action_queue=action_queue,
     )
 
-    assert not response.get(
-        "error"
-    )  # UnicornViewError/AssertionError returns a a JsonResponse with "error" key
+    assert not response.get("error")  # UnicornViewError/AssertionError returns a a JsonResponse with "error" key
     assert not response["errors"]
 
 
@@ -96,9 +89,7 @@ def test_message_decimal(client):
         action_queue=action_queue,
     )
 
-    assert not response.get(
-        "error"
-    )  # UnicornViewError/AssertionError returns a a JsonResponse with "error" key
+    assert not response.get("error")  # UnicornViewError/AssertionError returns a a JsonResponse with "error" key
     assert not response["errors"]
 
 
@@ -117,7 +108,5 @@ def test_message_dataclass(client):
         action_queue=action_queue,
     )
 
-    assert not response.get(
-        "error"
-    )  # UnicornViewError/AssertionError returns a a JsonResponse with "error" key
+    assert not response.get("error")  # UnicornViewError/AssertionError returns a a JsonResponse with "error" key
     assert not response["errors"]

--- a/tests/views/message/utils.py
+++ b/tests/views/message/utils.py
@@ -7,11 +7,12 @@ from django_unicorn.utils import generate_checksum
 
 def post_and_get_response(
     client,
+    *,
     url="",
     data=None,
     action_queue=None,
     component_id=None,
-    hash=None,
+    hash=None,  # noqa: A002
     return_response=False,
 ):
     if not data:

--- a/tests/views/test_process_component_request.py
+++ b/tests/views/test_process_component_request.py
@@ -1,5 +1,6 @@
-from django_unicorn.components import UnicornView
 from tests.views.message.utils import post_and_get_response
+
+from django_unicorn.components import UnicornView
 
 
 class FakeComponent(UnicornView):

--- a/tests/views/test_unicorn_dict.py
+++ b/tests/views/test_unicorn_dict.py
@@ -3,8 +3,8 @@ from django_unicorn.views.utils import set_property_from_data
 
 
 class DictPropertyView(UnicornView):
-    dictionary = {"name": "dictionary"}
-    nested_dictionary = {"nested": {"name": "nested_dictionary"}}
+    dictionary = {"name": "dictionary"}  # noqa: RUF012
+    nested_dictionary = {"nested": {"name": "nested_dictionary"}}  # noqa: RUF012
 
 
 def test_set_property_from_data_dict():
@@ -26,6 +26,4 @@ def test_set_property_from_data_nested_dict():
         {"nested": {"name": "nested_dictionary_updated"}},
     )
 
-    assert "nested_dictionary_updated" == component.nested_dictionary.get("nested").get(
-        "name"
-    )
+    assert "nested_dictionary_updated" == component.nested_dictionary.get("nested").get("name")

--- a/tests/views/test_unicorn_field.py
+++ b/tests/views/test_unicorn_field.py
@@ -33,6 +33,4 @@ def test_set_property_from_data_nested_unicorn_field():
     data = {"nested_property_one": {"name": "nested_property_one_updated"}}
     set_property_from_data(component, "property_one", data)
 
-    assert (
-        "nested_property_one_updated" == component.property_one.nested_property_one.name
-    )
+    assert "nested_property_one_updated" == component.property_one.nested_property_one.name

--- a/tests/views/test_unicorn_set_property_value.py
+++ b/tests/views/test_unicorn_set_property_value.py
@@ -21,9 +21,9 @@ class PropertyView(UnicornView):
 
 
 class FakeComponent(UnicornView):
-    flavors = []
+    flavors = []  # noqa: RUF012
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         self.flavors = list(Flavor.objects.all())
 
         super().__init__(**kwargs)

--- a/tests/views/utils/test_construct_model.py
+++ b/tests/views/utils/test_construct_model.py
@@ -39,9 +39,7 @@ def test_construct_model_foreign_key():
 
 
 @pytest.mark.django_db
-@pytest.mark.skip(
-    "This test isn't all that helpful unless related models get serialized"
-)
+@pytest.mark.skip("This test isn't all that helpful unless related models get serialized")
 def test_construct_model_recursive_foreign_key():
     flavor = Flavor(name="first-flavor")
     flavor.save()


### PR DESCRIPTION
- Switch from `isort` and `flake8` to `ruff`
- Includes lots of automatically generated fixes and one-off `noqa` markers
- Remove `isort` check from GitHub actions
- Add `ruff` check to GitHub actions
- Add `black` config to `pyproject.toml`