### PR TITLE
Catch `NameError` when getting type hints

### DIFF
--- a/django_unicorn/typer.py
+++ b/django_unicorn/typer.py
@@ -78,7 +78,7 @@ def get_type_hints(obj) -> Dict:
         type_hints_cache[obj] = type_hints
 
         return type_hints
-    except TypeError:
+    except (TypeError, NameError):
         # Return an empty dictionary when there is a TypeError. From `get_type_hints`: "TypeError is
         # raised if the argument is not of a type that can contain annotations, and an empty dictionary
         # is returned if no annotations are present"

--- a/tests/test_typer.py
+++ b/tests/test_typer.py
@@ -1,6 +1,8 @@
+import datetime
 from typing import Optional
 from typing import get_type_hints as typing_get_type_hints
 
+from django_unicorn.components import UnicornView
 from django_unicorn.typer import cast_attribute_value, cast_value, get_type_hints
 from example.coffee.models import Flavor
 
@@ -20,6 +22,15 @@ def test_get_type_hints_missing_type_hints():
 
     expected = {}
     actual = get_type_hints(test_func)
+    assert actual == expected
+
+
+def test_get_type_hints_gh_639():
+    class MyComponentView(UnicornView):
+        a_date: datetime.date
+
+    expected = {"a_date": datetime.date}
+    actual = get_type_hints(MyComponentView(component_name="test", component_id="123"))
     assert actual == expected
 
 


### PR DESCRIPTION
For https://github.com/adamghill/django-unicorn/issues/639.