### PR TITLE
Add fallback component location

### DIFF
--- a/django_unicorn/components/unicorn_view.py
+++ b/django_unicorn/components/unicorn_view.py
@@ -131,6 +131,9 @@ def get_locations(component_name: str) -> List[Tuple[str, str]]:
         app_module_name = f"{app}.components.{module_name}"
         locations.append((app_module_name, class_name))
 
+    # Add default directory to the end of the list as a fallback
+    locations.append((f"components.{module_name}", class_name))
+
     return locations
 
 

--- a/tests/components/test_get_locations.py
+++ b/tests/components/test_get_locations.py
@@ -19,21 +19,25 @@ def clear_apps(settings):
 
 
 def test_get_locations_kebab_case(cache_clear):  # noqa: ARG001
-    expected = [("unicorn.components.hello_world", "HelloWorldView")]
+    expected = [("unicorn.components.hello_world", "HelloWorldView"), ("components.hello_world", "HelloWorldView")]
     actual = get_locations("hello-world")
 
     assert expected == actual
 
 
 def test_get_locations_with_slashes(cache_clear):  # noqa: ARG001
-    expected = [("unicorn.components.nested.table", "TableView")]
+    expected = [("unicorn.components.nested.table", "TableView"), ("components.nested.table", "TableView")]
     actual = get_locations("nested/table")
 
     assert expected == actual
 
 
 def test_get_locations_with_dots(cache_clear):  # noqa: ARG001
-    expected = [("nested", "table"), ("unicorn.components.nested.table", "TableView")]
+    expected = [
+        ("nested", "table"),
+        ("unicorn.components.nested.table", "TableView"),
+        ("components.nested.table", "TableView"),
+    ]
     actual = get_locations("nested.table")
 
     assert expected == actual
@@ -49,9 +53,7 @@ def test_get_locations_fully_qualified_with_dots(cache_clear):  # noqa: ARG001
 
 
 def test_get_locations_fully_qualified_with_slashes(cache_clear):  # noqa: ARG001
-    expected = [
-        ("project.components.hello_world", "HelloWorldView"),
-    ]
+    expected = [("project.components.hello_world", "HelloWorldView")]
     actual = get_locations("project/components/hello_world.HelloWorldView")
 
     assert expected == actual
@@ -68,7 +70,7 @@ def test_get_locations_fully_qualified_with_dots_ends_in_component(cache_clear):
 
 def test_get_locations_fully_qualified_with_dots_does_not_end_in_view(cache_clear):  # noqa: ARG001
     """
-    The second entry in here is a mess.
+    The last 2 entries in here are a mess. This documents how things work correctly even though it is not the ideal.
     """
 
     expected = [
@@ -77,6 +79,7 @@ def test_get_locations_fully_qualified_with_dots_does_not_end_in_view(cache_clea
             "unicorn.components.project.components.hello_world.HelloWorldThing",
             "HelloworldthingView",
         ),
+        ("components.project.components.hello_world.HelloWorldThing", "HelloworldthingView"),
     ]
     actual = get_locations("project.components.hello_world.HelloWorldThing")
 
@@ -88,6 +91,7 @@ def test_get_locations_apps_setting_tuple(settings, cache_clear):  # noqa: ARG00
 
     expected = [
         ("project.components.hello_world", "HelloWorldView"),
+        ("components.hello_world", "HelloWorldView"),
     ]
     actual = get_locations("hello-world")
 
@@ -99,9 +103,7 @@ def test_get_locations_apps_setting_list(settings, cache_clear):  # noqa: ARG001
         "project",
     ]
 
-    expected = [
-        ("project.components.hello_world", "HelloWorldView"),
-    ]
+    expected = [("project.components.hello_world", "HelloWorldView"), ("components.hello_world", "HelloWorldView")]
     actual = get_locations("hello-world")
 
     assert expected == actual
@@ -114,6 +116,7 @@ def test_get_locations_apps_setting_set(settings, cache_clear):  # noqa: ARG001
 
     expected = [
         ("project.components.hello_world", "HelloWorldView"),
+        ("components.hello_world", "HelloWorldView"),
     ]
     actual = get_locations("hello-world")
 
@@ -135,14 +138,20 @@ def test_get_locations_installed_app_with_app_config(settings, clear_apps, cache
         "example.coffee.apps.Config",
     ]
 
-    expected = [("example.coffee.components.hello_world", "HelloWorldView")]
+    expected = [
+        ("example.coffee.components.hello_world", "HelloWorldView"),
+        ("components.hello_world", "HelloWorldView"),
+    ]
     actual = get_locations("hello-world")
 
     assert expected == actual
 
     # test when the app is in a subdirectory "apps" with Config
     settings.INSTALLED_APPS[0] = "foo_project.apps.bar_app.apps.Config"
-    expected_location = [("foo_project.apps.bar_app.components.foo_bar", "FooBarView")]
+    expected_location = [
+        ("foo_project.apps.bar_app.components.foo_bar", "FooBarView"),
+        ("components.foo_bar", "FooBarView"),
+    ]
     actual_location = get_locations("foo-bar")
     assert expected_location == actual_location
 
@@ -152,6 +161,9 @@ def test_get_locations_installed_app_with_apps(settings, clear_apps, cache_clear
     settings.INSTALLED_APPS = [
         "example.apps.main",
     ]
-    expected_location = [("example.apps.main.components.sidebar_menu", "SidebarMenuView")]
+    expected_location = [
+        ("example.apps.main.components.sidebar_menu", "SidebarMenuView"),
+        ("components.sidebar_menu", "SidebarMenuView"),
+    ]
     actual_location = get_locations("sidebar-menu")
     assert expected_location == actual_location

--- a/tests/views/message/test_message.py
+++ b/tests/views/message/test_message.py
@@ -98,7 +98,7 @@ def test_message_component_module_not_loaded(client):
         e.exconly()
         == "django_unicorn.errors.ComponentModuleLoadError: The component module 'test' could not be loaded."
     )
-    assert e.value.locations == [("unicorn.components.test", "TestView")]
+    assert e.value.locations == [("unicorn.components.test", "TestView"), ("components.test", "TestView")]
 
 
 def test_message_component_class_not_loaded(client):
@@ -126,6 +126,10 @@ has no attribute 'FakeComponentNotThere'"
         ("tests.views.fake_components", "FakeComponentNotThere"),
         (
             "unicorn.components.tests.views.fake_components.FakeComponentNotThere",
+            "FakecomponentnotthereView",
+        ),
+        (
+            "components.tests.views.fake_components.FakeComponentNotThere",
             "FakecomponentnotthereView",
         ),
     ]


### PR DESCRIPTION
Add a fallback location for components for a defined place to look that doesn't require adding something to `INSTALLED_APPS`. Added for `Coltrane`, but this might be useful for other use-cases as well.