### PR TITLE
Fix issues when using nested components in a direct view

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
-      - name: black check
-        run: poetry run black . --check
-
       - name: ruff check
         run: poetry run ruff .
 

--- a/django_unicorn/components/unicorn_view.py
+++ b/django_unicorn/components/unicorn_view.py
@@ -379,8 +379,6 @@ class UnicornView(TemplateView):
         self.mount()
         self.hydrate()
 
-        self._cache_component(**kwargs)
-
         return self.render_to_response(
             context=self.get_context_data(),
             component=self,

--- a/django_unicorn/views/__init__.py
+++ b/django_unicorn/views/__init__.py
@@ -351,6 +351,7 @@ def _process_component_request(request: HttpRequest, component_request: Componen
                     if isinstance(_child, Tag) and child_soup_unicorn_id == _child.attrs.get("unicorn:id"):
                         _child.attrs["unicorn:checksum"] = child_soup_checksum
 
+                parent_soup = get_root_element(parent_soup)
                 parent_dom = str(parent_soup)
 
                 # Remove the child DOM from the payload since the parent DOM supersedes it

--- a/docs/source/child-components.md
+++ b/docs/source/child-components.md
@@ -2,7 +2,7 @@
 
 `Unicorn` supports nesting components so that one component is a child of another. Since HTML is a tree structure, a component can have multiple children, but each child only has one parent.
 
-We will slowly build a nested component example with three components: table, filter and row. The table is the parent and contains the other two components. The filter will update the parent table component, and the row will contain functionality to edit a row.
+We will slowly build a nested component example with three components: `table`, `filter`, and `row`. The table is the parent and contains the other two components. The filter will update the parent table component, and the row will contain functionality to edit a row.
 
 ## Parent component
 
@@ -68,6 +68,9 @@ class FilterView(UnicornView):
             self.parent.books = list(
                 filter(lambda f: query.lower() in f.title.lower(), self.parent.books)
             )
+        
+        # Forces the parent to re-render instead of just the current component
+        self.parent.force_render = True
 ```
 
 ## Multiple children

--- a/docs/source/direct-view.md
+++ b/docs/source/direct-view.md
@@ -1,6 +1,6 @@
 # Direct View
 
-Usually components will be included in a regular Django template, however a component can also be specified in a `urls.py` file in instances where the having an additional template is not necessary.
+Usually components will be included in a regular Django template, however a component can also be specified in a `urls.py` file in instances where having an additional template is not necessary.
 
 ## Template Requirements
 

--- a/docs/source/views.md
+++ b/docs/source/views.md
@@ -191,7 +191,24 @@ class HelloWorldView(UnicornView):
 
 ### force_render
 
-Forces the component to render. This is not normally needed for the current component, but is sometimes needed for a parent component.
+Forces the component to render. This is not normally needed for the current component, but is sometimes needed when a child component needs a parent to re-render.
+
+```python
+# filter.py
+from django_unicorn.components import UnicornView
+
+class FilterView(UnicornView):
+    search = ""
+
+    def updated_search(self, query):
+        self.parent.load_table()
+
+        if query:
+            self.parent.books = list(filter(lambda f: query.lower() in f.name.lower(), self.parent.books))
+
+        # Forces the parent to re-render instead of just the current child component
+        self.parent.force_render = True
+```
 
 ## Custom methods
 

--- a/example/unicorn/templates/unicorn/nested/filter.html
+++ b/example/unicorn/templates/unicorn/nested/filter.html
@@ -1,4 +1,5 @@
+<!-- filter.html -->
 <div>
-    Filter: <input type="text" unicorn:model="search" /><br />
-    Search: "{{ search }}"
+  Filter: <input type="text" unicorn:model="search" /><br />
+  Search: "{{ search }}"
 </div>

--- a/example/unicorn/templates/unicorn/nested/row.html
+++ b/example/unicorn/templates/unicorn/nested/row.html
@@ -1,3 +1,4 @@
+<!-- row.html -->
 {% load unicorn %}
 <tr>
   <td>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ docs = ["Sphinx", "linkify-it-py", "myst-parser", "furo", "sphinx-copybutton", "
 certifi = "^2023.7.22"  # needed for GitHub Actions
 keyring = "24.2.0"  # needed for GitHub Actions
 pytest = "^7"
-black = "*"
 mypy = "<1"
 django-stubs = "*"
 pytest-django = "*"
@@ -57,11 +56,6 @@ coverage = {extras = ["toml"], version = "*"}
 pytest-cov = "*"
 pytest-benchmark = "*"
 ruff = "*"
-
-[tool.black]
-target-version = ["py38", "py39", "py310"]
-line-length = 120
-extend-exclude = "migrations"
 
 [tool.ruff]
 src = ["django_unicorn"]
@@ -153,12 +147,11 @@ tbc = { cmd = "pytest tests/benchmarks/ --benchmark-only --benchmark-compare", h
 tc = { cmd = "pytest --cov=django_unicorn", help = "Run tests with coverage" }
 cr = { cmd = "coverage report", help = "Show coverage report" }
 my = { cmd = "mypy .", help = "Run mypy" }
-b = { cmd = "black . --check --quiet --extend-exclude migrations", help = "Run black" }
 rf = { cmd = "ruff .", help = "Run ruff" }
-tm = ["b", "rf", "tc", "my"]
+tm = ["rf", "tc", "my"]
 sa = { cmd = "sphinx-autobuild -W docs/source docs/build", help = "Sphinx autobuild" }
 sb = { cmd = "sphinx-build -W docs/source docs/build", help = "Build documentation" }
-build = ["b", "rf", "tc", "ji", "tj", "jb", "sb"]
+build = ["rf", "tc", "ji", "tj", "jb", "sb"]
 publish = { shell = "poetry publish --build -r test && poetry publish" }
 
 [build-system]

--- a/tests/components/test_unicorn_template_response.py
+++ b/tests/components/test_unicorn_template_response.py
@@ -78,6 +78,28 @@ def test_get_root_element_direct_view_u():
     assert str(actual) == expected
 
 
+def test_get_root_element_as_direct_view_unicorn():
+    # Annoyingly beautifulsoup adds a blank string on the attribute
+    expected = '<div unicorn:view="">test</div>'
+
+    component_html = "<div unicorn:view>test</div>"
+    soup = BeautifulSoup(component_html, features="html.parser")
+    actual = get_root_element(soup)
+
+    assert str(actual) == expected
+
+
+def test_get_root_element_as_direct_view_u():
+    # Annoyingly beautifulsoup adds a blank string on the attribute
+    expected = '<div u:view="">test</div>'
+
+    component_html = "<div u:view>test</div>"
+    soup = BeautifulSoup(component_html, features="html.parser")
+    actual = get_root_element(soup)
+
+    assert str(actual) == expected
+
+
 def test_get_root_element_direct_view_no_view():
     component_html = "<html><head></head>≤body><div>test</div></body></html>"
     soup = BeautifulSoup(component_html, features="html.parser")


### PR DESCRIPTION
For #662 and CCing @jacksund for visibility.

Fixes a few issues:
- child components that had `force_render=True` would always get the parent component's outer element, however direct views are special since they are embedded in a regular template; make sure to send back the actual root element for the parent DOM
- clean up a logged warning about multiple elements for direct views
- clean up some docs
- fix the `'PointerUnicornView' object has no attribute 'component_id'` error that happens when refreshing a direct view
- more doc fixes to make `force_render` more clear