### PR TITLE
Delete json_tag from child components as it could cause RecursionError

### DIFF
--- a/django_unicorn/components/unicorn_template_response.py
+++ b/django_unicorn/components/unicorn_template_response.py
@@ -247,6 +247,11 @@ potentially cause errors in Unicorn."
                     for child in descendant.children:
                         init_script = f"{init_script} {child._init_script}"
                         json_tags.append(child._json_tag)
+                        # We need to delete this property here as it can cause RecursionError
+                        # when pickling child component. Tag element has previous_sibling
+                        # and next_sibling which would also be pickled and if they are big,
+                        # cause RecursionError
+                        del child._json_tag
                         descendants.append(child)
 
                 script_tag = soup.new_tag("script")


### PR DESCRIPTION
Fixes #477 even though it's closed.

The cause of the problem was that  `_json_tag` was being added to child components which is a bs4 `Tag`.

It contains a lot of properties most notably [previous_sibling and next_sibling](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#next-sibling-and-previous-sibling) which depending on their size can cause `RecursionError`.