### PR TITLE
Fixed missing form_class in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ class TodoForm(forms.Form):
     task = forms.CharField(min_length=2, max_length=20, required=True)
 
 class TodoView(UnicornView):
+    form_class = TodoForm
+
     task = ""
     tasks = []
 


### PR DESCRIPTION
- Just starting up with unicorn recently, great project. I think the `form_class` actually is missing from the README here. Let me know if that is not right.