### PR TITLE
Add unicorn:bind as synonym for unicorn:model

### DIFF
--- a/docs/source/templates.md
+++ b/docs/source/templates.md
@@ -27,6 +27,8 @@ This template is **valid**:
 
 `Unicorn` element attributes usually start with `unicorn:`, however the shortcut `u:` is also supported. So, for example, `unicorn:model` could also be written as `u:model`.
 
+`unicorn:bind` can also be used as a synonym for `unicorn:model` (and `u:bind` for `u:model`).
+
 ## Accessing nested fields
 
 Fields in a `dictionary` or Django model can be accessed similarly to the Django template language with "dot notation".

--- a/src/django_unicorn/static/unicorn/js/attribute.js
+++ b/src/django_unicorn/static/unicorn/js/attribute.js
@@ -32,7 +32,7 @@ export class Attribute {
       this.isUnicorn = true;
 
       // Use `contains` when there could be modifiers
-      if (contains(this.name, ":model")) {
+      if (contains(this.name, ":model") || contains(this.name, ":bind")) {
         this.isModel = true;
       } else if (contains(this.name, ":poll.disable")) {
         this.isPollDisable = true;

--- a/tests/js/element/bind.test.js
+++ b/tests/js/element/bind.test.js
@@ -1,0 +1,49 @@
+import test from "ava";
+import { getElement } from "../utils.js";
+
+test("bind", (t) => {
+    const html = "<input unicorn:bind='name'></input>";
+    const element = getElement(html);
+
+    t.is(element.model.name, "name");
+    t.is(element.model.eventType, "input");
+    t.false(element.model.isLazy);
+    t.false(element.model.isDefer);
+});
+
+test("bind.defer", (t) => {
+    const html = "<input unicorn:bind.defer='name'></input>";
+    const element = getElement(html);
+
+    t.true(element.model.isDefer);
+});
+
+test("bind.lazy", (t) => {
+    const html = "<input unicorn:bind.lazy='name'></input>";
+    const element = getElement(html);
+
+    t.true(element.model.isLazy);
+    t.is(element.model.eventType, "blur");
+});
+
+test("bind.debounce", (t) => {
+    const html = "<input unicorn:bind.debounce='name'></input>";
+    const element = getElement(html);
+
+    t.is(element.model.debounceTime, -1);
+});
+
+test("bind.debounce-1000", (t) => {
+    const html = "<input unicorn:bind.debounce-1000='name'></input>";
+    const element = getElement(html);
+
+    t.is(element.model.debounceTime, 1000);
+});
+
+test("bind.lazy.debounce-500", (t) => {
+    const html = "<input unicorn:bind.lazy.debounce-500='name'></input>";
+    const element = getElement(html);
+
+    t.true(element.model.isLazy);
+    t.is(element.model.debounceTime, 500);
+});


### PR DESCRIPTION
Add unicorn:bind as a synonym for unicorn:model. Closes #711 