### PR TITLE
Fix get_type_hints to support inherited type hints

### DIFF
--- a/src/django_unicorn/typer.py
+++ b/src/django_unicorn/typer.py
@@ -92,7 +92,13 @@ def get_type_hints(obj) -> dict:
         pass
 
     try:
-        type_hints = typing_get_type_hints(obj)
+        if hasattr(obj, "__class__"):
+            # Should be called with class object (instead of instance) to get type hints of parent classes. From docs:
+            # "If obj is a class C, the function returns a dictionary that merges annotations from C’s base classes with those on C directly.
+            # This is done by traversing C.__mro__ and iteratively combining __annotations__ dictionaries." (https://docs.python.org/3/library/typing.html#typing.get_type_hints)
+            type_hints = typing_get_type_hints(obj.__class__)
+        else:
+            type_hints = typing_get_type_hints(obj)
 
         # Cache the type hints just in case
         type_hints_cache[obj] = type_hints

--- a/tests/components/test_typer_inheritance.py
+++ b/tests/components/test_typer_inheritance.py
@@ -1,0 +1,26 @@
+
+from typing import List
+from django_unicorn.typer import get_type_hints
+
+class Parent:
+    name: str
+
+class Child(Parent):
+    age: int
+
+def test_get_type_hints_inheritance():
+    """
+    Verify that get_type_hints returns type hints from parent classes
+    when called with an instance of a subclass.
+    """
+    instance = Child()
+    type_hints = get_type_hints(instance)
+    
+    assert "name" in type_hints
+    assert type_hints["name"] == str
+    assert "age" in type_hints
+    assert type_hints["age"] == int
+
+if __name__ == "__main__":
+    test_get_type_hints_inheritance()
+    print("Test passed!")


### PR DESCRIPTION
## Description
This PR fixes an issue where type hints defined in parent classes were not being detected when [get_type_hints](cci:1://file:///c:/Users/DELL/Documents/GitHub/django-unicorn/src/django_unicorn/typer.py:79:0-110:17) was called with a component instance. Closes #741