### PR TITLE
feat: Auto-initialize dynamically added Unicorn components via MutationObserver

### DIFF
--- a/docs/source/javascript.md
+++ b/docs/source/javascript.md
@@ -52,3 +52,19 @@ The first argument to `trigger` is the component name. The second argument is th
   Unicorn.trigger("hello_world", "nameKey");
 </script>
 ```
+
+## Dynamic Content
+
+Unicorn automatically initializes components that are dynamically added to the page (e.g. via `htmx`, `fetch`, or `innerHTML`) using a `MutationObserver`.
+
+If you need to manually check the DOM for new components, you can use `Unicorn.scan()`.
+
+```javascript
+// Scan the entire document
+Unicorn.scan();
+
+// Scan a specific element
+const container = document.getElementById('container');
+Unicorn.scan(container);
+```
+

--- a/src/django_unicorn/static/unicorn/js/unicorn.js
+++ b/src/django_unicorn/static/unicorn/js/unicorn.js
@@ -31,6 +31,23 @@ export function init(
     csrfTokenCookieName = _csrfTokenCookieName;
   }
 
+  if (typeof MutationObserver !== "undefined") {
+    const unicornObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            scan(node);
+          }
+        });
+      });
+    });
+
+    unicornObserver.observe(document, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
   return {
     messageUrl,
     csrfTokenHeaderName,
@@ -79,7 +96,27 @@ export function insertComponentFromDom(node) {
 }
 
 /**
- * Gets the component with the specified name or key.
+ * Scans the DOM for any component roots and initializes them if they haven't been already.
+ * @param {Element} root The root element to scan. Defaults to document.
+ */
+export function scan(root) {
+  if (!root) {
+    root = document;
+  }
+
+  if (root.hasAttribute && root.hasAttribute("unicorn:id")) {
+    insertComponentFromDom(root);
+  }
+
+  const elements = root.querySelectorAll("[unicorn\\:id]");
+
+  elements.forEach((element) => {
+    insertComponentFromDom(element);
+  });
+}
+
+/**
+ * Gets the component wit h the specified name or key.
  * Component keys are searched first, then names.
  *
  * @param {String} componentNameOrKey The name or key of the component to search for.

--- a/tests/js/unicorn/scan.test.js
+++ b/tests/js/unicorn/scan.test.js
@@ -1,0 +1,59 @@
+import test from "ava";
+import { JSDOM } from "jsdom";
+import { scan, init } from "../../../src/django_unicorn/static/unicorn/js/unicorn.js";
+import { components } from "../../../src/django_unicorn/static/unicorn/js/store.js";
+
+test.beforeEach(() => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    global.document = dom.window.document;
+    global.window = dom.window;
+    global.MutationObserver = dom.window.MutationObserver;
+    global.Node = dom.window.Node;
+    global.NodeFilter = dom.window.NodeFilter;
+
+    // Clear components
+    for (const key in components) {
+        delete components[key];
+    }
+});
+
+test.afterEach(() => {
+    delete global.document;
+    delete global.window;
+    delete global.MutationObserver;
+    delete global.Node;
+});
+
+test("scan initializes component from dom", (t) => {
+    const componentRoot = document.createElement("div");
+    componentRoot.setAttribute("unicorn:id", "test-scan-id");
+    componentRoot.setAttribute("unicorn:name", "test-name");
+    componentRoot.setAttribute("unicorn:key", "test-key");
+    componentRoot.setAttribute("unicorn:checksum", "test-checksum");
+    componentRoot.setAttribute("unicorn:data", "{}");
+    componentRoot.setAttribute("unicorn:calls", "[]");
+    document.body.appendChild(componentRoot);
+
+    scan();
+
+    t.truthy(components["test-scan-id"]);
+});
+
+test("init observes document automatically", async (t) => {
+    init("unicorn/", "X-Unicorn", "unicorn", { NAME: "morphdom" });
+
+    const componentRoot = document.createElement("div");
+    componentRoot.setAttribute("unicorn:id", "test-auto-id");
+    componentRoot.setAttribute("unicorn:name", "test-name");
+    componentRoot.setAttribute("unicorn:key", "test-key");
+    componentRoot.setAttribute("unicorn:checksum", "test-checksum");
+    componentRoot.setAttribute("unicorn:data", "{}");
+    componentRoot.setAttribute("unicorn:calls", "[]");
+
+    document.body.appendChild(componentRoot);
+
+    // Wait for MutationObserver (microtask/macrotask)
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    t.truthy(components["test-auto-id"]);
+});


### PR DESCRIPTION
## Description

This PR adds automatic component initialization for nodes added to the DOM dynamically (e.g., via `innerHTML`, `fetch`, `htmx`, or other JavaScript libraries).

Previously, components injected after the initial page load would not be interactive unless manually initialized. This change introduces a `MutationObserver` in `Unicorn.init()` that watches for added nodes and initializes any Unicorn components found within them.

Closes #502