### PR TITLE
Fix IndexError in custom setter with empty value

### DIFF
--- a/src/django_unicorn/views/action_parsers/call_method.py
+++ b/src/django_unicorn/views/action_parsers/call_method.py
@@ -173,8 +173,9 @@ def _call_method_name(component: UnicornView, method_name: str, args: tuple[Any]
                     value = None
 
                     if not kwargs:
-                        value = args[len(parsed_args)]
-                        parsed_args.append(DbModel.objects.get(**{key: value}))
+                        if len(args) > len(parsed_args):
+                            value = args[len(parsed_args)]
+                            parsed_args.append(DbModel.objects.get(**{key: value}))
                     else:
                         value = kwargs.get("pk")
                         parsed_kwargs[argument] = DbModel.objects.get(**{key: value})
@@ -186,7 +187,8 @@ def _call_method_name(component: UnicornView, method_name: str, args: tuple[Any]
             elif argument in kwargs:
                 parsed_kwargs[argument] = kwargs[argument]
             else:
-                parsed_args.append(args[len(parsed_args)])
+                if len(args) > len(parsed_args):
+                    parsed_args.append(args[len(parsed_args)])
 
         if parsed_args:
             return func(*parsed_args, **parsed_kwargs)

--- a/tests/views/fake_components.py
+++ b/tests/views/fake_components.py
@@ -198,3 +198,11 @@ class FakeComponentWithResolveMethods(UnicornView):
         count_resolved += 1
 
         assert count_resolved == 1, "count_resolved called more than once"
+
+
+class BugComponent(UnicornView):
+    template_name = "templates/test_component.html"
+    flavor: str = "initial"
+
+    def set_flavor(self, value: str = ""):
+        self.flavor = value

--- a/tests/views/message/test_call_method.py
+++ b/tests/views/message/test_call_method.py
@@ -405,3 +405,24 @@ def test_message_call_method_validation_error_string_no_code(client):
 
     assert body["error"]
     assert body["error"] == "Error code must be specified"
+
+
+def test_gh_628_custom_setter_empty_string(client):
+    data = {"flavor": "initial"}
+    # Simulate set_flavor() call with no args (empty string case)
+    action_queue = [
+        {
+            "payload": {"name": "set_flavor()"}, 
+            "type": "callMethod",
+        }
+    ]
+
+    response = post_and_get_response(
+        client,
+        url="/message/tests.views.fake_components.BugComponent",
+        data=data,
+        action_queue=action_queue,
+    )
+
+    assert not response["errors"]
+    assert response["data"]["flavor"] == ""


### PR DESCRIPTION
## Description
Fixes #628.

When using a custom setter method with `$event.target.value`, selecting an empty value caused the backend to receive a method call with no arguments ([set_flavor()]. The action parser in [call_method.py] would then try to access [args] without checking its length, leading to an `IndexError: tuple index out of range`.

This PR adds a check to ensure args has elements before accessing them by index.
