### PR TITLE
Fix: Include child component JavaScript calls in response

### DIFF
--- a/src/django_unicorn/components/unicorn_view.py
+++ b/src/django_unicorn/components/unicorn_view.py
@@ -147,7 +147,7 @@ def construct_component(
     )
 
     component.calls = []
-    component.children = []
+    
 
     component._mount_result = component.mount()
     component.hydrate()

--- a/tests/views/message/test_calls.py
+++ b/tests/views/message/test_calls.py
@@ -66,3 +66,117 @@ def test_message_calls_with_arg(client):
     response = post_and_get_response(client, url=FAKE_CALLS_COMPONENT_URL, action_queue=action_queue)
 
     assert response.get("calls") == [{"args": ["hello"], "fn": "testCall3"}]
+
+
+class FakeChildComponent(UnicornView):
+    template_name = "templates/test_component.html"
+
+    def child_method(self):
+        self.call("createChart", {"data": "test"})
+
+
+class FakeParentComponent(UnicornView):
+    template_name = "templates/test_component.html"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Create a child component
+        child = FakeChildComponent(component_name="fake-child", id="child-123")
+        child.parent = self
+        self.children.append(child)
+
+    def call_child_method(self):
+        # Parent calls child's method
+        for child in self.children:
+            if hasattr(child, "child_method") and callable(child.child_method):
+                child.child_method()  # type: ignore[call-top-callable]
+
+
+FAKE_PARENT_COMPONENT_URL = "/message/tests.views.message.test_calls.FakeParentComponent"
+
+
+def test_message_child_calls_from_parent(client):
+    """Test that child component calls are included when parent calls child method."""
+    action_queue = [
+        {
+            "payload": {"name": "call_child_method"},
+            "type": "callMethod",
+            "target": None,
+        }
+    ]
+
+    response = post_and_get_response(client, url=FAKE_PARENT_COMPONENT_URL, action_queue=action_queue)
+
+    # Verify child's JavaScript call is in the response
+    calls = response.get("calls", [])
+    assert any(call["fn"] == "createChart" for call in calls), f"Expected 'createChart' in calls, got: {calls}"
+    assert len(calls) == 1
+    assert calls[0]["args"] == [{"data": "test"}]
+
+
+class FakeGrandchildComponent(UnicornView):
+    template_name = "templates/test_component.html"
+
+    def grandchild_method(self):
+        self.call("grandchildFunction", "nested")
+
+
+class FakeChildWithGrandchildComponent(UnicornView):
+    template_name = "templates/test_component.html"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Create a grandchild component
+        grandchild = FakeGrandchildComponent(component_name="fake-grandchild", id="grandchild-456")
+        grandchild.parent = self
+        self.children.append(grandchild)
+
+    def child_method_with_call(self):
+        self.call("childFunction")
+        # Also call grandchild's method
+        for child in self.children:
+            if hasattr(child, "grandchild_method") and callable(child.grandchild_method):
+                child.grandchild_method()  # type: ignore[call-top-callable]
+
+
+class FakeParentWithNestedChildren(UnicornView):
+    template_name = "templates/test_component.html"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Create a child component with its own child
+        child = FakeChildWithGrandchildComponent(component_name="fake-child-nested", id="child-nested-789")
+        child.parent = self
+        self.children.append(child)
+
+    def call_nested_children(self):
+        self.call("parentFunction")
+        # Call child's method which will also call grandchild
+        for child in self.children:
+            if hasattr(child, "child_method_with_call") and callable(child.child_method_with_call):
+                child.child_method_with_call()  # type: ignore[call-top-callable]
+
+
+FAKE_NESTED_COMPONENT_URL = "/message/tests.views.message.test_calls.FakeParentWithNestedChildren"
+
+
+def test_message_nested_child_calls(client):
+    """Test that grandchild component calls are included in deeply nested scenarios."""
+    action_queue = [
+        {
+            "payload": {"name": "call_nested_children"},
+            "type": "callMethod",
+            "target": None,
+        }
+    ]
+
+    response = post_and_get_response(client, url=FAKE_NESTED_COMPONENT_URL, action_queue=action_queue)
+
+    # Verify all levels of calls are collected: parent, child, and grandchild
+    calls = response.get("calls", [])
+    call_functions = [call["fn"] for call in calls]
+
+    assert "parentFunction" in call_functions, f"Expected 'parentFunction' in calls, got: {call_functions}"
+    assert "childFunction" in call_functions, f"Expected 'childFunction' in calls, got: {call_functions}"
+    assert "grandchildFunction" in call_functions, f"Expected 'grandchildFunction' in calls, got: {call_functions}"
+    assert len(calls) == 3

--- a/tests/views/test_m2m_overwriting.py
+++ b/tests/views/test_m2m_overwriting.py
@@ -11,12 +11,13 @@ class M2MComponent(UnicornView):
 
     def mount(self):
         if self.component_args:
-             self.taste = Taste.objects.get(pk=self.component_args[0])
+            self.taste = Taste.objects.get(pk=self.component_args[0])
 
     def refresh(self):
         # usage: unicorn:poll="refresh"
         if self.taste:
             self.taste = Taste.objects.get(pk=self.taste.pk)
+
 
 @pytest.mark.django_db
 def test_m2m_overwriting(client):

--- a/tests/views/test_unit_views.py
+++ b/tests/views/test_unit_views.py
@@ -86,6 +86,7 @@ def test_component_response_structure():
     component = Mock(spec=Component)
     component.errors = {}
     component.calls = []
+    component.children = []
     component.parent = None
     component.force_render = False
 


### PR DESCRIPTION
When a parent component calls a child component's method, and that child method uses self.call() to queue JavaScript function calls, those calls were not being included in the response sent to the frontend.

Closes #559