### PR TITLE
feat: Use Django signing for payload protection

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core.signing import loads as signing_loads
 from django.template.backends.django import Template
 
 from django_unicorn.utils import (
@@ -13,29 +14,28 @@ from django_unicorn.utils import (
 def test_generate_checksum_bytes(settings):
     settings.SECRET_KEY = "asdf"
 
-    expected = "TfxFqcQL"
     actual = generate_checksum(b'{"name": "test"}')
-
-    assert expected == actual
+    # Verify it's a signed string that can be unsigned
+    unsigned = signing_loads(actual, salt="django-unicorn")
+    assert unsigned == '{"name": "test"}'
 
 
 def test_generate_checksum_str(settings):
     settings.SECRET_KEY = "asdf"
 
-    expected = "TfxFqcQL"
     actual = generate_checksum('{"name": "test"}')
-
-    assert expected == actual
+    # Verify it's a signed string that can be unsigned
+    unsigned = signing_loads(actual, salt="django-unicorn")
+    assert unsigned == '{"name": "test"}'
 
 
 def test_generate_checksum_dict(settings):
     settings.SECRET_KEY = "asdf"
 
-    # This is different than the above because `str(dict)` turns `{"name": "test"}` into `"{'name': 'test'}"`
-    expected = "JaV4PeA6"
     actual = generate_checksum({"name": "test"})
-
-    assert expected == actual
+    # Verify it's a signed dict that can be unsigned
+    unsigned = signing_loads(actual, salt="django-unicorn")
+    assert unsigned == {"name": "test"}
 
 
 def test_generate_checksum_invalid(settings):

--- a/tests/views/message/test_call_method.py
+++ b/tests/views/message/test_call_method.py
@@ -77,7 +77,7 @@ def test_message_call_method_redirect_with_message(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }

--- a/tests/views/message/test_message.py
+++ b/tests/views/message/test_message.py
@@ -1,10 +1,12 @@
 import time
+from typing import cast
 from uuid import uuid4
 
 import pytest
 from django.http import JsonResponse
 
 from django_unicorn.errors import ComponentClassLoadError, ComponentModuleLoadError
+from django_unicorn.utils import generate_checksum
 from django_unicorn.views import message
 
 
@@ -69,16 +71,17 @@ def test_message_bad_checksum(client):
 def test_message_no_component_id(client):
     data = {
         "data": {},
-        "checksum": "DVVk97cx",
         "epoch": time.time(),
     }
+    data["checksum"] = generate_checksum(cast(dict, data["data"]))
     response = post_json(client, data, url="/message/test-message-no-component-id")
 
     assert_json_error(response, "Missing component id")
 
 
 def test_message_no_epoch(client):
-    data = {"data": {}, "checksum": "DVVk97cx", "id": str(uuid4())}
+    data = {"data": {}, "id": str(uuid4())}
+    data["checksum"] = generate_checksum(cast(dict, data["data"]))
     response = post_json(client, data, url="/message/test-message-no-epoch")
 
     assert_json_error(response, "Missing epoch")
@@ -87,10 +90,10 @@ def test_message_no_epoch(client):
 def test_message_component_module_not_loaded(client):
     data = {
         "data": {},
-        "checksum": "DVVk97cx",
         "id": str(uuid4()),
         "epoch": time.time(),
     }
+    data["checksum"] = generate_checksum(cast(dict, data["data"]))
 
     with pytest.raises(ComponentModuleLoadError) as e:
         post_json(client, data, url="/message/test-message-module-not-loaded")
@@ -108,10 +111,10 @@ def test_message_component_module_not_loaded(client):
 def test_message_component_class_not_loaded(client):
     data = {
         "data": {},
-        "checksum": "DVVk97cx",
         "id": str(uuid4()),
         "epoch": time.time(),
     }
+    data["checksum"] = generate_checksum(cast(dict, data["data"]))
 
     with pytest.raises(ComponentClassLoadError) as e:
         post_json(
@@ -143,10 +146,10 @@ has no attribute 'FakeComponentNotThere'"
 def test_message_component_class_with_attribute_error(client):
     data = {
         "data": {},
-        "checksum": "DVVk97cx",
         "id": str(uuid4()),
         "epoch": time.time(),
     }
+    data["checksum"] = generate_checksum(cast(dict, data["data"]))
 
     with pytest.raises(ComponentClassLoadError) as e:
         post_json(
@@ -161,10 +164,10 @@ def test_message_component_class_with_attribute_error(client):
 def test_message_component_with_dash(client):
     data = {
         "data": {},
-        "checksum": "DVVk97cx",
         "id": str(uuid4()),
         "epoch": time.time(),
     }
+    data["checksum"] = generate_checksum(cast(dict, data["data"]))
 
     with pytest.raises(ComponentModuleLoadError) as e:
         post_json(client, data, url="/message/test-with-dash")
@@ -178,10 +181,10 @@ def test_message_component_with_dash(client):
 def test_message_component_with_dot(client):
     data = {
         "data": {},
-        "checksum": "DVVk97cx",
         "id": str(uuid4()),
         "epoch": time.time(),
     }
+    data["checksum"] = generate_checksum(cast(dict, data["data"]))
 
     with pytest.raises(ComponentClassLoadError) as e:
         post_json(client, data, url="/message/test.dot")

--- a/tests/views/message/test_set_property.py
+++ b/tests/views/message/test_set_property.py
@@ -24,7 +24,7 @@ def test_setter(client):
             {"type": "callMethod", "payload": {"name": "check=True"}},
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -42,7 +42,7 @@ def test_setter_updated(client):
             {"type": "callMethod", "payload": {"name": "count=2"}},
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -69,7 +69,7 @@ def test_setter_resolved(client):
     message = {
         "actionQueue": action_queue,
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -93,7 +93,7 @@ def test_nested_setter(client):
             {"type": "callMethod", "payload": {"name": "nested.check=True"}},
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -114,7 +114,7 @@ def test_equal_sign(client):
             },
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }

--- a/tests/views/message/test_target.py
+++ b/tests/views/message/test_target.py
@@ -27,7 +27,7 @@ def test_message_generated_checksum_matches_dom_checksum(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -60,7 +60,7 @@ def test_message_target_invalid(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -89,7 +89,7 @@ def test_message_target_id(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -120,7 +120,7 @@ def test_message_target_only_id(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -151,7 +151,7 @@ def test_message_target_only_key(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -182,7 +182,7 @@ def test_message_target_key(client):
             }
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }

--- a/tests/views/message/test_toggle.py
+++ b/tests/views/message/test_toggle.py
@@ -24,7 +24,7 @@ def test_message_toggle(client):
             {"type": "callMethod", "payload": {"name": "$toggle('check')"}},
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }
@@ -42,7 +42,7 @@ def test_message_nested_toggle(client):
             {"type": "callMethod", "payload": {"name": "$toggle('nested.check')"}},
         ],
         "data": data,
-        "checksum": generate_checksum(str(data)),
+        "checksum": generate_checksum(data),
         "id": shortuuid.uuid()[:8],
         "epoch": time.time(),
     }

--- a/tests/views/test_unit_views.py
+++ b/tests/views/test_unit_views.py
@@ -1,4 +1,5 @@
 import json
+from typing import cast
 from unittest.mock import Mock
 
 import pytest
@@ -45,7 +46,7 @@ def test_component_request_parsing():
         "checksum": "fail",
     }
 
-    body["checksum"] = generate_checksum(str(body["data"]))
+    body["checksum"] = generate_checksum(cast(dict, body["data"]))
 
     request.body = json.dumps(body).encode("utf-8")
 
@@ -71,7 +72,7 @@ def test_component_request_action_parsing():
         ],
     }
 
-    body["checksum"] = generate_checksum(str(body["data"]))
+    body["checksum"] = generate_checksum(cast(dict, body["data"]))
     request.body = json.dumps(body).encode("utf-8")
 
     req = ComponentRequest(request, "test-component")


### PR DESCRIPTION
This PR replaces the custom HMAC-based checksum generation with Django's built-in cryptographic signing framework (django.core.signing). This provides stronger protection against payload tampering and leverages Django's standard security mechanisms. Closes #124