### PR TITLE
Fix: u:loading on child elements no longer disables parent u:click

### DIFF
--- a/src/django_unicorn/static/unicorn/js/eventListeners.js
+++ b/src/django_unicorn/static/unicorn/js/eventListeners.js
@@ -134,6 +134,18 @@ export function addActionEventListener(component, eventType) {
       targetElement = targetElement.getUnicornParent();
     }
 
+    // If the target element is a unicorn element but has no actions
+    // (e.g. it only has u:loading), traverse up to find the nearest
+    // ancestor that has actions for this event type.
+    // Fixes: u:loading on child elements intercepting clicks meant for parent u:click
+    if (
+      targetElement &&
+      targetElement.isUnicorn &&
+      targetElement.actions.length === 0
+    ) {
+      targetElement = targetElement.getUnicornParent();
+    }
+
     if (
       targetElement &&
       targetElement.isUnicorn &&

--- a/tests/js/component/loadingWithAction.test.js
+++ b/tests/js/component/loadingWithAction.test.js
@@ -1,0 +1,45 @@
+import test from "ava";
+import { getComponent } from "../utils.js";
+
+test("u:click action detected when child has u:loading", (t) => {
+    const html = `
+  <div unicorn:id="5jypjiyb" unicorn:name="text-inputs" unicorn:checksum="GXzew3Km">
+    <button unicorn:click="send_otp">
+      <span unicorn:loading.remove>Send One Time Password</span>
+      <span unicorn:loading>Sending...</span>
+    </button>
+  </div>`;
+    const component = getComponent(html);
+
+    t.false(component.actionEvents.click === undefined);
+    t.is(component.actionEvents.click.length, 1);
+    t.is(component.actionEvents.click[0].action.name, "send_otp");
+});
+
+test("u:click action detected when child has u:loading.class", (t) => {
+    const html = `
+  <div unicorn:id="5jypjiyb" unicorn:name="text-inputs" unicorn:checksum="GXzew3Km">
+    <button unicorn:click="send_otp">
+      <span unicorn:loading.class="loading">Send One Time Password</span>
+    </button>
+  </div>`;
+    const component = getComponent(html);
+
+    t.false(component.actionEvents.click === undefined);
+    t.is(component.actionEvents.click.length, 1);
+    t.is(component.actionEvents.click[0].action.name, "send_otp");
+});
+
+test("u:click with u:loading on same element still works", (t) => {
+    const html = `
+  <div unicorn:id="5jypjiyb" unicorn:name="text-inputs" unicorn:checksum="GXzew3Km">
+    <button unicorn:click="send_otp" unicorn:loading.class="loading-wrapper">
+      <span>Send One Time Password</span>
+    </button>
+  </div>`;
+    const component = getComponent(html);
+
+    t.false(component.actionEvents.click === undefined);
+    t.is(component.actionEvents.click.length, 1);
+    t.is(component.actionEvents.click[0].action.name, "send_otp");
+});


### PR DESCRIPTION
When u:loading or u:loading.remove was placed on a child element of a button with u:click, clicking the button no longer triggered the action. 

Root cause: u:loading makes the <span> a "unicorn element" (isUnicorn = true). When the span is clicked, 
addActionEventListener
 finds it as the target but sees it has no actions — and stops there. It never bubbles up to the parent <button> that actually has u:click.

Closes #416