### PR TITLE
fix: restore float values in nested tuple[dict] fields

### DIFF
--- a/src/django_unicorn/serializer.py
+++ b/src/django_unicorn/serializer.py
@@ -275,7 +275,17 @@ def _fix_floats(current: dict, data: dict | None = None, paths: list | None = No
             paths.append(key)
             _fix_floats(val, data, paths=paths)
             paths.pop()
-    elif isinstance(current, list):
+    elif isinstance(current, (list, tuple)):
+        if isinstance(current, tuple) and paths:
+            # Tuples are immutable; convert to list in the parent container so
+            # we can mutate float values inside it.
+            _piece = data
+            for idx, path in enumerate(paths):
+                if idx == len(paths) - 1:
+                    _piece[path] = list(current)
+                else:
+                    _piece = _piece[path]
+            current = _piece[paths[-1]]
         for idx, item in enumerate(current):
             paths.append(idx)
             _fix_floats(item, data, paths=paths)

--- a/tests/serializer/test_dumps.py
+++ b/tests/serializer/test_dumps.py
@@ -841,3 +841,33 @@ def test_dictionary_with_int_keys_as_strings_no_sort():
     )
 
     assert expected == actual
+
+
+def test_tuple_float():
+    """Float inside a tuple is stringified for safe JS transmission (#641)."""
+    import json
+
+    actual = serializer.dumps({"ranks": ({"name": "abc", "score": 3.4},)})
+    data = json.loads(actual)
+
+    assert data["ranks"][0]["score"] == "3.4"
+
+
+def test_tuple_of_dicts_mixed_types():
+    """Multiple floats and non-floats inside a tuple of dicts are handled (#641)."""
+    import json
+
+    actual = serializer.dumps(
+        {
+            "ranks": (
+                {"name": "abc", "score": 3.4},
+                {"name": "def", "score": 1.0},
+                {"name": "ghi", "score": 5},
+            )
+        }
+    )
+    data = json.loads(actual)
+
+    assert data["ranks"][0]["score"] == "3.4"
+    assert data["ranks"][1]["score"] == "1.0"
+    assert data["ranks"][2]["score"] == 5  # int stays as int


### PR DESCRIPTION
A component field annotated as tuple[dict[str, float|str]] would have its float values permanently converted to strings after the first browser round-trip. This broke any operation relying on numeric comparison (e.g. sorting by score) Closes #641