### PR TITLE
feat: Implement popstate support for history navigation

### DIFF
--- a/src/django_unicorn/static/unicorn/js/messageSender.js
+++ b/src/django_unicorn/static/unicorn/js/messageSender.js
@@ -108,7 +108,12 @@ export function send(component, callback) {
             }
 
             component.window.history.pushState(
-              {},
+              {
+                unicorn: {
+                  componentId: component.id,
+                  data: component.data,
+                },
+              },
               "",
               responseJson.redirect.url
             );

--- a/tests/js/component/historyState.test.js
+++ b/tests/js/component/historyState.test.js
@@ -1,0 +1,82 @@
+import test from "ava";
+import { getComponent } from "../utils.js";
+
+const html = `
+<input type="hidden" name="csrfmiddlewaretoken" value="asdf">
+<div unicorn:id="5jypjiyb" unicorn:name="text-inputs" unicorn:checksum="GXzew3Km">
+    <input unicorn:model='name'></input>
+    <button unicorn:click='test()'><span id="clicker">Click</span></button>
+</div>
+`;
+
+test("popstate listener is registered on window", (t) => {
+    const component = getComponent(html);
+
+    // The initHistoryState() call should have registered a popstate listener
+    t.truthy(component._windowEventListeners["popstate"]);
+    t.is(component._windowEventListeners["popstate"].length, 1);
+});
+
+test("popstate ignores events with no unicorn state", (t) => {
+    const component = getComponent(html);
+
+    // Fire a popstate event with no state — should not trigger any refresh
+    const listeners = component._windowEventListeners["popstate"];
+    t.truthy(listeners);
+
+    // actionQueue should be empty before and after
+    t.is(component.actionQueue.length, 0);
+
+    listeners[0]({ state: null });
+    t.is(component.actionQueue.length, 0);
+});
+
+test("popstate ignores events with non-matching component id", (t) => {
+    const component = getComponent(html);
+    const listeners = component._windowEventListeners["popstate"];
+
+    t.is(component.actionQueue.length, 0);
+
+    // Fire with a different componentId — should be ignored
+    listeners[0]({
+        state: {
+            unicorn: {
+                componentId: "different-id",
+                data: { name: "OldValue" },
+            },
+        },
+    });
+
+    t.is(component.actionQueue.length, 0);
+});
+
+test("popstate restores data and triggers refresh for matching component", (t) => {
+    const component = getComponent(html);
+    const listeners = component._windowEventListeners["popstate"];
+
+    // Spy on callMethod so we can verify $refresh is called without needing
+    // a working HTTP endpoint
+    const calledMethods = [];
+    component.callMethod = (methodName) => {
+        calledMethods.push(methodName);
+    };
+
+    const previousData = { name: "PreviousName" };
+
+    // Fire popstate with a matching componentId and stored previous state
+    listeners[0]({
+        state: {
+            unicorn: {
+                componentId: component.id,
+                data: previousData,
+            },
+        },
+    });
+
+    // The stored data should have been merged back into the component
+    t.is(component.data.name, "PreviousName");
+
+    // $refresh should have been called to trigger a server re-render
+    t.is(calledMethods.length, 1);
+    t.is(calledMethods[0], "$refresh");
+});

--- a/tests/js/component/messageSender.test.js
+++ b/tests/js/component/messageSender.test.js
@@ -80,6 +80,13 @@ test("call_method refresh redirect", async (t) => {
       t.true(err === null);
       t.is(component.window.history.get(), "/test/text-inputs?some=query");
       t.is(component.window.document.title, "new title");
+
+      // The history state should contain the component id and data
+      const state = component.window.history.getState();
+      t.truthy(state.unicorn);
+      t.is(state.unicorn.componentId, component.id);
+      t.deepEqual(state.unicorn.data, component.data);
+
       fetchMock.reset();
       resolve();
     });


### PR DESCRIPTION
This PR addresses issue #598 by enabling components to restore their state when navigating through browser history (Back/Forward buttons) after a LocationUpdate. Closes #598
.