### PR TITLE
 Remove a Component

### DIFF
--- a/docs/source/javascript.md
+++ b/docs/source/javascript.md
@@ -30,6 +30,34 @@ class CallJavascriptView(UnicornView):
 
     def hello(self):
         self.call("hello", self.name)
+```
+
+## Remove a Component
+
+Call `self.remove()` from any view method to remove the component's root element from the DOM. This is useful for list-item components (e.g. table rows or list items) that need to delete themselves without requiring a parent component to manage re-rendering.
+
+```python
+# todo_item.py
+from django_unicorn.components import UnicornView
+
+class TodoItemView(UnicornView):
+    item_id: int = 0
+
+    def delete(self):
+        # perform any server-side cleanup here
+        TodoItem.objects.filter(pk=self.item_id).delete()
+        self.remove()
+```
+
+```html
+<!-- todo-item.html -->
+<li>
+  {{ item_id }}
+  <button unicorn:click="delete">Delete</button>
+</li>
+```
+
+Calling `self.remove()` is shorthand for `self.call("Unicorn.deleteComponent", self.component_id)`. After the server responds, the component's root element is removed from the DOM and cleaned up from the internal component store.
 
 ## Call Method on Other Component
 

--- a/src/django_unicorn/components/unicorn_view.py
+++ b/src/django_unicorn/components/unicorn_view.py
@@ -331,6 +331,14 @@ class Component(TemplateView):
         """
         self.calls.append({"fn": function_name, "args": args})
 
+    def remove(self):
+        """
+        Remove this component's root element from the DOM and delete it from the
+        internal component store. Equivalent to calling
+        ``self.call("Unicorn.deleteComponent", self.component_id)``.
+        """
+        self.call("Unicorn.deleteComponent", self.component_id)
+
     def mount(self):
         """
         Hook that gets called when the component is first created.
@@ -825,6 +833,7 @@ class Component(TemplateView):
             "parent",
             "children",
             "call",
+            "remove",
             "calls",
             "component_cache_key",
             "component_kwargs",

--- a/src/django_unicorn/static/unicorn/js/unicorn.js
+++ b/src/django_unicorn/static/unicorn/js/unicorn.js
@@ -154,10 +154,17 @@ export function getComponent(componentNameOrKey) {
 }
 
 /**
- * Deletes the component from the component store.
+ * Removes the component's root element from the DOM and deletes it from the
+ * component store.
  * @param {String} componentId.
  */
 export function deleteComponent(componentId) {
+  const root = document.querySelector(`[unicorn\\:id="${componentId}"]`);
+
+  if (root) {
+    root.remove();
+  }
+
   delete components[componentId];
 }
 

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -210,6 +210,32 @@ def test_get_context_data_component_key():
     assert actual["unicorn"]["component_key"] == "key-key-key"
 
 
+def test_call_queues_js_function(component):
+    component.call("myFunction")
+    assert component.calls == [{"fn": "myFunction", "args": ()}]
+
+
+def test_call_queues_js_function_with_args(component):
+    component.call("myFunction", "hello", 42)
+    assert component.calls == [{"fn": "myFunction", "args": ("hello", 42)}]
+
+
+def test_remove_queues_delete_component_call(component):
+    component.remove()
+    assert len(component.calls) == 1
+    assert component.calls[0]["fn"] == "Unicorn.deleteComponent"
+    assert component.calls[0]["args"] == (component.component_id,)
+
+
+def test_remove_uses_own_component_id(component):
+    component.remove()
+    assert component.calls[0]["args"][0] == "asdf1234"
+
+
+def test_remove_is_not_public_attribute(component):
+    assert component._is_public("remove") is False
+
+
 def test_is_public(component):
     assert component._is_public("test_name")
 

--- a/tests/js/unicorn/deleteComponent.test.js
+++ b/tests/js/unicorn/deleteComponent.test.js
@@ -1,0 +1,63 @@
+import test from "ava";
+import { JSDOM } from "jsdom";
+import { deleteComponent } from "../../../src/django_unicorn/static/unicorn/js/unicorn.js";
+import { components } from "../../../src/django_unicorn/static/unicorn/js/store.js";
+
+test.beforeEach(() => {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>");
+  global.document = dom.window.document;
+
+  // Clear components store between tests
+  for (const key in components) {
+    delete components[key];
+  }
+});
+
+test.afterEach(() => {
+  delete global.document;
+});
+
+test("deleteComponent removes component from store", (t) => {
+  const componentId = "test-delete-id";
+  components[componentId] = { id: componentId };
+
+  deleteComponent(componentId);
+
+  t.falsy(components[componentId]);
+});
+
+test("deleteComponent removes root element from DOM", (t) => {
+  const componentId = "test-dom-remove-id";
+  components[componentId] = { id: componentId };
+
+  const root = document.createElement("div");
+  root.setAttribute("unicorn:id", componentId);
+  document.body.appendChild(root);
+
+  t.truthy(document.querySelector(`[unicorn\\:id="${componentId}"]`));
+
+  deleteComponent(componentId);
+
+  t.falsy(document.querySelector(`[unicorn\\:id="${componentId}"]`));
+});
+
+test("deleteComponent is a no-op when element is not in DOM", (t) => {
+  const componentId = "test-no-dom-id";
+  components[componentId] = { id: componentId };
+
+  // Element was never added to the DOM — should not throw
+  t.notThrows(() => deleteComponent(componentId));
+  t.falsy(components[componentId]);
+});
+
+test("deleteComponent is a no-op when component is not in store", (t) => {
+  const componentId = "test-no-store-id";
+
+  const root = document.createElement("div");
+  root.setAttribute("unicorn:id", componentId);
+  document.body.appendChild(root);
+
+  // Component not in store — element should still be removed
+  t.notThrows(() => deleteComponent(componentId));
+  t.falsy(document.querySelector(`[unicorn\\:id="${componentId}"]`));
+});

--- a/tests/views/message/test_calls.py
+++ b/tests/views/message/test_calls.py
@@ -15,6 +15,9 @@ class FakeCallsComponent(UnicornView):
     def test_call3(self):
         self.call("testCall3", "hello")
 
+    def test_remove(self):
+        self.remove()
+
 
 FAKE_CALLS_COMPONENT_URL = "/message/tests.views.message.test_calls.FakeCallsComponent"
 
@@ -66,6 +69,23 @@ def test_message_calls_with_arg(client):
     response = post_and_get_response(client, url=FAKE_CALLS_COMPONENT_URL, action_queue=action_queue)
 
     assert response.get("calls") == [{"args": ["hello"], "fn": "testCall3"}]
+
+
+def test_message_remove(client):
+    component_id = "test-remove-id"
+    action_queue = [
+        {
+            "payload": {"name": "test_remove"},
+            "type": "callMethod",
+            "target": None,
+        }
+    ]
+
+    response = post_and_get_response(
+        client, url=FAKE_CALLS_COMPONENT_URL, action_queue=action_queue, component_id=component_id
+    )
+
+    assert response.get("calls") == [{"args": [component_id], "fn": "Unicorn.deleteComponent"}]
 
 
 class FakeChildComponent(UnicornView):


### PR DESCRIPTION
Extended deleteComponent(componentId) to first query for the component's  root element ([unicorn:id="..."]) and call remove() on it before  deleting it from the JS component store. Closes #454 