### PR TITLE
  fix: surface broken import errors when loading components

### DIFF
--- a/src/django_unicorn/components/unicorn_view.py
+++ b/src/django_unicorn/components/unicorn_view.py
@@ -1017,8 +1017,15 @@ class Component(TemplateView):
 
                 return component
             except ModuleNotFoundError as e:
-                logger.debug(e)
-                pass
+                # Only silently skip when the module we're looking for simply doesn't
+                # exist.  If a *different* module is missing it means the component file
+                # was found and started executing but contains a broken import - that
+                # error should be surfaced rather than swallowed.
+                if e.name is None or module_name == e.name or module_name.startswith(e.name + "."):
+                    logger.debug(e)
+                else:
+                    message = f"The component module '{module_name}' could not be loaded: {e}"
+                    raise ComponentModuleLoadError(message, locations=locations) from e
             except AttributeError as e:
                 logger.debug(e)
                 attribute_exception = e

--- a/tests/views/fake_components_with_broken_import.py
+++ b/tests/views/fake_components_with_broken_import.py
@@ -1,0 +1,7 @@
+from nonexistent_package_xyz_abc import SomeClass  # noqa: F401  # type: ignore[import]
+
+from django_unicorn.components import UnicornView
+
+
+class FakeComponentWithBrokenImport(UnicornView):
+    template_name = "templates/test_component.html"

--- a/tests/views/message/test_message.py
+++ b/tests/views/message/test_message.py
@@ -156,6 +156,31 @@ def test_message_component_class_with_attribute_error(client):
         )
 
     assert e.value.__cause__
+    # The original AttributeError should be included in the message so the
+    # developer can see what actually went wrong, not just that loading failed.
+    assert "not_a_valid_attribute" in e.exconly()
+
+
+def test_message_component_module_with_broken_import(client):
+    """A component that exists but contains a broken import should surface the
+    underlying ModuleNotFoundError rather than masking it with a generic
+    "component module could not be loaded" message (issue #380)."""
+    data = {
+        "data": {},
+        "meta": "DVVk97cx",
+        "id": str(uuid4()),
+        "epoch": time.time(),
+    }
+
+    with pytest.raises(ComponentModuleLoadError) as e:
+        post_json(
+            client,
+            data,
+            url="/message/tests.views.fake_components_with_broken_import.FakeComponentWithBrokenImport",
+        )
+
+    assert e.value.__cause__
+    assert "nonexistent_package_xyz_abc" in e.exconly()
 
 
 def test_message_component_with_dash(client):


### PR DESCRIPTION
Previously, a ModuleNotFoundError raised by a *broken import inside* a   component file (e.g. `from nonexistent_pkg import Foo`) was silently  swallowed along with all other ModuleNotFoundErrors, leaving the  developer with only the generic "component module could not be loaded"   message and no clue that their file was found but failed to execute.      
Now the except clause checks e.name against the module being searched:  if a *different* module is missing, the error is immediately re-raised as ComponentModuleLoadError with the original exception chained, so the  real cause is visible in the traceback.  Closes #380